### PR TITLE
feat: alias old commands in force namespace

### DIFF
--- a/src/commands/auth/device/login.ts
+++ b/src/commands/auth/device/login.ts
@@ -19,6 +19,8 @@ const commonMessages = Messages.loadMessages('@salesforce/plugin-auth', 'message
 export default class Login extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static aliases = ['force:auth:device:login'];
+
   public static readonly flagsConfig: FlagsConfig = {
     clientid: flags.string({
       char: 'i',

--- a/src/commands/auth/jwt/grant.ts
+++ b/src/commands/auth/jwt/grant.ts
@@ -18,6 +18,8 @@ const commonMessages = Messages.loadMessages('@salesforce/plugin-auth', 'message
 export default class Grant extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static aliases = ['force:auth:jwt:grant'];
+
   public static readonly flagsConfig: FlagsConfig = {
     username: flags.string({
       char: 'u',

--- a/src/commands/auth/list.ts
+++ b/src/commands/auth/list.ts
@@ -23,6 +23,8 @@ export type AuthListInfo = {
 
 export default class List extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
+  public static aliases = ['force:auth:list'];
+
   public static readonly flagsConfig: FlagsConfig = {};
   public async run(): Promise<Authorization[]> {
     try {

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -17,6 +17,8 @@ export default class Logout extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly supportsUsername = true;
+  public static aliases = ['force:auth:logout'];
+
   public static readonly flagsConfig: FlagsConfig = {
     all: flags.boolean({
       char: 'a',

--- a/src/commands/auth/sfdxurl/store.ts
+++ b/src/commands/auth/sfdxurl/store.ts
@@ -21,6 +21,8 @@ const AUTH_URL_FORMAT2 = 'force://<clientId>:<clientSecret>:<refreshToken>@<inst
 export default class Store extends SfdxCommand {
   public static readonly description = messages.getMessage('description', [AUTH_URL_FORMAT1, AUTH_URL_FORMAT2]);
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static aliases = ['force:auth:sfdxurl:store'];
+
   public static readonly flagsConfig: FlagsConfig = {
     sfdxurlfile: flags.filepath({
       char: 'f',

--- a/src/commands/auth/web/login.ts
+++ b/src/commands/auth/web/login.ts
@@ -21,6 +21,8 @@ const commonMessages = Messages.loadMessages('@salesforce/plugin-auth', 'message
 export default class Login extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static aliases = ['force:auth:web:login'];
+
   public static readonly flagsConfig: FlagsConfig = {
     clientid: flags.string({
       char: 'i',


### PR DESCRIPTION
### What does this PR do?
Aliases the old auth commands in the `force` namespace

### What issues does this PR fix or reference?
@W-8039212@