### PR TITLE
fix: device login with instanceurl

### DIFF
--- a/src/commands/auth/device/login.ts
+++ b/src/commands/auth/device/login.ts
@@ -9,6 +9,7 @@ import * as os from 'os';
 
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { AuthFields, DeviceOauthService, Messages, OAuth2Options } from '@salesforce/core';
+import { get, Optional } from '@salesforce/ts-types';
 import { Prompts } from '../../../prompts';
 import { Common } from '../../../common';
 
@@ -52,7 +53,7 @@ export default class Login extends SfdxCommand {
     if (await Prompts.shouldExitCommand(this.ux, this.flags.noprompt)) return {};
 
     const oauthConfig: OAuth2Options = {
-      loginUrl: this.flags.instanceurl,
+      loginUrl: get(this.flags.instanceurl, 'href', null) as Optional<string>,
       clientId: this.flags.clientid,
     };
 

--- a/test/commands/auth/device/login.test.ts
+++ b/test/commands/auth/device/login.test.ts
@@ -95,6 +95,18 @@ describe('auth:device:login', async () => {
   test
     .do(async () => prepareStubs())
     .stdout()
+    .command(['auth:device:login', '-r', 'https://login.salesforce.com', '--json'])
+    .it('should return auth fields with instance url', (ctx) => {
+      const [action, response] = parseJsonResponse(ctx.stdout);
+      expect(action).to.deep.equal(mockAction);
+      expect(response.status).to.equal(0);
+      expect(response.result).to.deep.equal(authFields);
+      expect(response.result.username).to.equal(testData.username);
+    });
+
+  test
+    .do(async () => prepareStubs())
+    .stdout()
     .command(['auth:device:login', '-a', 'MyAlias', '--json'])
     .it('should set alias when -a is provided', (ctx) => {
       const [action, response] = parseJsonResponse(ctx.stdout);


### PR DESCRIPTION
### What does this PR do?
Fixes issue with `auth:device:login` when `instanceurl` flag is provided

### What issues does this PR fix or reference?
