### PR TITLE
test: add NUTs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@salesforce/dev-scripts": "^0.9.1",
     "@salesforce/plugin-command-reference": "^1.3.0",
     "@salesforce/prettier-config": "^0.0.2",
+    "@salesforce/plugin-config": "^1.2.5",
     "@salesforce/ts-sinon": "^1.2.3",
     "@types/mkdirp": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
@@ -73,9 +74,10 @@
     "commands": "./lib/commands",
     "bin": "sfdx",
     "devPlugins": [
-      "@oclif/plugin-help",
       "@oclif/plugin-command-snapshot",
-      "@salesforce/plugin-command-reference"
+      "@oclif/plugin-help",
+      "@salesforce/plugin-command-reference",
+      "@salesforce/plugin-config"
     ],
     "topics": {
       "auth": {

--- a/src/commands/auth/list.ts
+++ b/src/commands/auth/list.ts
@@ -11,16 +11,6 @@ import { AuthInfo, Authorization, Messages } from '@salesforce/core';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-auth', 'list');
 
-export type AuthListInfo = {
-  alias: string;
-  username: string;
-  orgId: string;
-  instanceUrl: string;
-  accessToken?: string;
-  oauthMethod?: 'jwt' | 'web' | 'token' | 'unknown';
-  error?: string;
-};
-
 export default class List extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
   public static aliases = ['force:auth:list'];

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -22,9 +22,5 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'off',
     // Easily return a promise in a mocked method.
     '@typescript-eslint/require-await': 'off',
-
-    '@typescript-eslint/no-unsafe-assignment': 'off',
-    '@typescript-eslint/no-unsafe-return': 'off',
-    '@typescript-eslint/no-unsafe-member-access': 'off',
   },
 };

--- a/test/commands/auth/device/login.test.ts
+++ b/test/commands/auth/device/login.test.ts
@@ -18,6 +18,7 @@ import { DeviceOauthService } from '@salesforce/core';
 import { DeviceCodeResponse } from '@salesforce/core/lib/deviceOauthService';
 import { UX } from '@salesforce/command';
 import { SinonStub } from 'sinon';
+import { parseJson } from '../../../testHelper';
 
 interface Options {
   approvalTimesout?: boolean;
@@ -233,7 +234,7 @@ describe('auth:device:login', async () => {
     .stdout()
     .command(['auth:device:login', '--json'])
     .it('should exit early when prompt is answered NO', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(uxStub.callCount).to.equal(1);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal({});

--- a/test/commands/auth/jwt/grant.nut.ts
+++ b/test/commands/auth/jwt/grant.nut.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { execCmd, TestSession, prepareForJwt } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString } from '@salesforce/ts-types';
+import { ensureString, getString } from '@salesforce/ts-types';
 import { AuthFields } from '@salesforce/core';
 import { expectUrlToExist, expectOrgIdToExist, expectAccessTokenToExist } from '../../../testHelper';
 
@@ -52,7 +52,8 @@ describe('auth:jwt:grant NUTs', () => {
 
   it('should authorize an org using jwt (human readable)', () => {
     const command = `auth:jwt:grant -d -u ${username} -i ${clientId} -f ${jwtKey} -r ${instanceUrl}`;
-    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+    const result = execCmd(command, { ensureExitCode: 0 });
+    const output = getString(result, 'shellOutput.stdout');
     expect(output).to.include(`Successfully authorized ${username} with org ID`);
   });
 });

--- a/test/commands/auth/jwt/grant.nut.ts
+++ b/test/commands/auth/jwt/grant.nut.ts
@@ -58,6 +58,6 @@ describe('auth:jwt:grant NUTs', () => {
     const command = `auth:jwt:grant -d -u ${username} -i ${clientId} -f ${jwtKey} -r ${instanceUrl}`;
     const result = execCmd(command, { ensureExitCode: 0 });
     const output = getString(result, 'shellOutput.stdout', '');
-    expect(output).to.equal(`Successfully authorized ${username} with org ID 00DB0000000EfT0MAK\n`);
+    expect(output).to.include(`Successfully authorized ${username} with org ID 00DB0000000EfT0MAK`);
   });
 });

--- a/test/commands/auth/jwt/grant.nut.ts
+++ b/test/commands/auth/jwt/grant.nut.ts
@@ -4,44 +4,60 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import * as path from 'path';
+import { execCmd, TestSession, prepareForJwt } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString } from '@salesforce/ts-types';
-import { AuthorizationResult, expectAccessTokenToExist, scrubAccessTokens } from '../../../testHelper';
+import { ensureString, getString } from '@salesforce/ts-types';
+import { AuthFields } from '@salesforce/core';
+import { Result, expectPropsToExist, scrubSecrets } from '../../../testHelper';
 
 let testSession: TestSession;
 
 describe('auth:jwt:grant NUTs', () => {
   const env = new Env();
+  let jwtKey: string;
+  let username: string;
+  let instanceUrl: string;
+  let clientId: string;
 
-  before('ensure required environment variables exist', () => {
+  before('prepare session and ensure environment variables', () => {
+    username = ensureString(env.getString('TESTKIT_HUB_USERNAME'));
+    instanceUrl = ensureString(env.getString('TESTKIT_HUB_INSTANCE'));
+    clientId = ensureString(env.getString('TESTKIT_JWT_CLIENT_ID'));
     ensureString(env.getString('TESTKIT_JWT_KEY'));
-    ensureString(env.getString('TESTKIT_JWT_CLIENT_ID'));
-    ensureString(env.getString('TESTKIT_HUB_INSTANCE'));
-    ensureString(env.getString('TESTKIT_HUB_USERNAME'));
+
+    testSession = TestSession.create({ authStrategy: 'NONE' });
+    jwtKey = prepareForJwt(testSession.homeDir);
   });
 
-  beforeEach(() => {
-    testSession = TestSession.create({});
-  });
-
-  afterEach(async () => {
+  after(async () => {
     await testSession.clean();
   });
 
-  it('should authorize an org using jwt', () => {
-    // TestSession does jwt auth for us, so we just want to make sure that the auth file exists
-    const json = execCmd('auth:list --json', { ensureExitCode: 0 }).jsonOutput as AuthorizationResult;
-    expectAccessTokenToExist(json.result[0]);
-    const auths = scrubAccessTokens(json.result);
-    expect(auths).to.deep.equal([
-      {
-        instanceUrl: 'https://gs0-dev-hub.my.salesforce.com',
-        oauthMethod: 'jwt',
-        orgId: '00DB0000000EfT0MAK',
-        username: 'admin@integrationtesthubgs0.org',
-      },
-    ]);
+  afterEach(() => {
+    execCmd(`auth:logout -p -u ${username}`, { ensureExitCode: 0 });
+  });
+
+  it('should authorize an org using jwt (json)', () => {
+    const command = `auth:jwt:grant -d -u ${username} -i ${clientId} -f ${jwtKey} -r ${instanceUrl} --json`;
+    const json = execCmd(command, { ensureExitCode: 0 }).jsonOutput as Result<AuthFields>;
+
+    expectPropsToExist(json.result, 'accessToken');
+    const auths = scrubSecrets(json.result);
+    expect(auths).to.deep.equal({
+      username,
+      orgId: '00DB0000000EfT0MAK',
+      loginUrl: 'https://login.salesforce.com/',
+      privateKey: path.join(testSession.homeDir, 'jwtKey'),
+      instanceUrl: 'https://gs0-dev-hub.my.salesforce.com',
+    });
+  });
+
+  it('should authorize an org using jwt (human readable)', () => {
+    const command = `auth:jwt:grant -d -u ${username} -i ${clientId} -f ${jwtKey} -r ${instanceUrl}`;
+    const result = execCmd(command, { ensureExitCode: 0 });
+    const output = getString(result, 'shellOutput.stdout', '');
+    expect(output).to.equal(`Successfully authorized ${username} with org ID 00DB0000000EfT0MAK\n`);
   });
 });

--- a/test/commands/auth/jwt/grant.nut.ts
+++ b/test/commands/auth/jwt/grant.nut.ts
@@ -10,7 +10,7 @@ import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
 import { ensureString, getString } from '@salesforce/ts-types';
 import { AuthFields } from '@salesforce/core';
-import { Result, expectPropsToExist, scrubSecrets } from '../../../testHelper';
+import { Result, expectUrlToExist, expectOrgIdToExist, expectAccessTokenToExist } from '../../../testHelper';
 
 let testSession: TestSession;
 
@@ -43,15 +43,12 @@ describe('auth:jwt:grant NUTs', () => {
     const command = `auth:jwt:grant -d -u ${username} -i ${clientId} -f ${jwtKey} -r ${instanceUrl} --json`;
     const json = execCmd(command, { ensureExitCode: 0 }).jsonOutput as Result<AuthFields>;
 
-    expectPropsToExist(json.result, 'accessToken');
-    const auths = scrubSecrets(json.result);
-    expect(auths).to.deep.equal({
-      username,
-      orgId: '00DB0000000EfT0MAK',
-      loginUrl: 'https://login.salesforce.com/',
-      privateKey: path.join(testSession.homeDir, 'jwtKey'),
-      instanceUrl: 'https://gs0-dev-hub.my.salesforce.com',
-    });
+    expectAccessTokenToExist(json.result);
+    expectOrgIdToExist(json.result);
+    expectUrlToExist(json.result, 'instanceUrl');
+    expectUrlToExist(json.result, 'loginUrl');
+    expect(json.result.privateKey).to.equal(path.join(testSession.homeDir, 'jwtKey'));
+    expect(json.result.username).to.equal(username);
   });
 
   it('should authorize an org using jwt (human readable)', () => {

--- a/test/commands/auth/jwt/grant.nut.ts
+++ b/test/commands/auth/jwt/grant.nut.ts
@@ -55,6 +55,6 @@ describe('auth:jwt:grant NUTs', () => {
     const command = `auth:jwt:grant -d -u ${username} -i ${clientId} -f ${jwtKey} -r ${instanceUrl}`;
     const result = execCmd(command, { ensureExitCode: 0 });
     const output = getString(result, 'shellOutput.stdout', '');
-    expect(output).to.include(`Successfully authorized ${username} with org ID 00DB0000000EfT0MAK`);
+    expect(output).to.include(`Successfully authorized ${username} with org ID`);
   });
 });

--- a/test/commands/auth/jwt/grant.nut.ts
+++ b/test/commands/auth/jwt/grant.nut.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { Env } from '@salesforce/kit';
+import { ensureString } from '@salesforce/ts-types';
+import { AuthorizationResult, expectAccessTokenToExist, scrubAccessTokens } from '../../../testHelper';
+
+let testSession: TestSession;
+
+describe('auth:jwt:grant NUTs', () => {
+  const env = new Env();
+
+  before('ensure required environment variables exist', () => {
+    ensureString(env.getString('TESTKIT_JWT_KEY'));
+    ensureString(env.getString('TESTKIT_JWT_CLIENT_ID'));
+    ensureString(env.getString('TESTKIT_HUB_INSTANCE'));
+    ensureString(env.getString('TESTKIT_HUB_USERNAME'));
+  });
+
+  beforeEach(() => {
+    testSession = TestSession.create({});
+  });
+
+  afterEach(async () => {
+    await testSession.clean();
+  });
+
+  it('should authorize an org using jwt', () => {
+    // TestSession does jwt auth for us, so we just want to make sure that the auth file exists
+    const json = execCmd('auth:list --json', { ensureExitCode: 0 }).jsonOutput as AuthorizationResult;
+    expectAccessTokenToExist(json.result[0]);
+    const auths = scrubAccessTokens(json.result);
+    expect(auths).to.deep.equal([
+      {
+        instanceUrl: 'https://gs0-dev-hub.my.salesforce.com',
+        oauthMethod: 'jwt',
+        orgId: '00DB0000000EfT0MAK',
+        username: 'admin@integrationtesthubgs0.org',
+      },
+    ]);
+  });
+});

--- a/test/commands/auth/jwt/grant.nut.ts
+++ b/test/commands/auth/jwt/grant.nut.ts
@@ -8,9 +8,9 @@ import * as path from 'path';
 import { execCmd, TestSession, prepareForJwt } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString, getString } from '@salesforce/ts-types';
+import { ensureString } from '@salesforce/ts-types';
 import { AuthFields } from '@salesforce/core';
-import { Result, expectUrlToExist, expectOrgIdToExist, expectAccessTokenToExist } from '../../../testHelper';
+import { expectUrlToExist, expectOrgIdToExist, expectAccessTokenToExist } from '../../../testHelper';
 
 let testSession: TestSession;
 
@@ -32,7 +32,7 @@ describe('auth:jwt:grant NUTs', () => {
   });
 
   after(async () => {
-    await testSession.clean();
+    await testSession?.clean();
   });
 
   afterEach(() => {
@@ -41,8 +41,7 @@ describe('auth:jwt:grant NUTs', () => {
 
   it('should authorize an org using jwt (json)', () => {
     const command = `auth:jwt:grant -d -u ${username} -i ${clientId} -f ${jwtKey} -r ${instanceUrl} --json`;
-    const json = execCmd(command, { ensureExitCode: 0 }).jsonOutput as Result<AuthFields>;
-
+    const json = execCmd<AuthFields>(command, { ensureExitCode: 0 }).jsonOutput;
     expectAccessTokenToExist(json.result);
     expectOrgIdToExist(json.result);
     expectUrlToExist(json.result, 'instanceUrl');
@@ -53,8 +52,7 @@ describe('auth:jwt:grant NUTs', () => {
 
   it('should authorize an org using jwt (human readable)', () => {
     const command = `auth:jwt:grant -d -u ${username} -i ${clientId} -f ${jwtKey} -r ${instanceUrl}`;
-    const result = execCmd(command, { ensureExitCode: 0 });
-    const output = getString(result, 'shellOutput.stdout', '');
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.include(`Successfully authorized ${username} with org ID`);
   });
 });

--- a/test/commands/auth/jwt/grant.test.ts
+++ b/test/commands/auth/jwt/grant.test.ts
@@ -10,6 +10,7 @@ import { AuthFields, AuthInfo, SfdxError } from '@salesforce/core';
 import { MockTestOrgData } from '@salesforce/core/lib/testSetup';
 import { StubbedType, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { UX } from '@salesforce/command';
+import { parseJson, parseJsonError } from '../../../testHelper';
 
 interface Options {
   authInfoCreateFails?: boolean;
@@ -49,7 +50,7 @@ describe('auth:jwt:grant', async () => {
     .stdout()
     .command(['auth:jwt:grant', '-u', testData.username, '-f', 'path/to/key.json', '-i', '123456', '--json'])
     .it('should return auth fields', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
     });
@@ -70,7 +71,7 @@ describe('auth:jwt:grant', async () => {
       '--json',
     ])
     .it('should set alias when -a is provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.callCount).to.equal(1);
@@ -93,7 +94,7 @@ describe('auth:jwt:grant', async () => {
       '--json',
     ])
     .it('should set defaultusername to alias when -s and -a are provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.args[0]).to.deep.equal(['MyAlias']);
@@ -111,7 +112,7 @@ describe('auth:jwt:grant', async () => {
     .stdout()
     .command(['auth:jwt:grant', '-u', testData.username, '-f', 'path/to/key.json', '-i', '123456', '-s', '--json'])
     .it('should set defaultusername to username when -s is provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.callCount).to.equal(0);
@@ -141,7 +142,7 @@ describe('auth:jwt:grant', async () => {
       '--json',
     ])
     .it('should set defaultdevhubusername to alias when -d and -a are provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.args[0]).to.deep.equal(['MyAlias']);
@@ -159,7 +160,7 @@ describe('auth:jwt:grant', async () => {
     .stdout()
     .command(['auth:jwt:grant', '-u', testData.username, '-f', 'path/to/key.json', '-i', '123456', '-d', '--json'])
     .it('should set defaultdevhubusername to username when -d is provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.callCount).to.equal(0);
@@ -188,7 +189,7 @@ describe('auth:jwt:grant', async () => {
       '--json',
     ])
     .it('should set defaultusername and defaultdevhubusername to username when -d and -s are provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.callCount).to.equal(0);
@@ -219,7 +220,7 @@ describe('auth:jwt:grant', async () => {
       '--json',
     ])
     .it('should set defaultusername and defaultdevhubusername to alias when -a, -d, and -s are provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.args[0]).to.deep.equal(['MyAlias']);
@@ -237,7 +238,7 @@ describe('auth:jwt:grant', async () => {
     .stdout()
     .command(['auth:jwt:grant', '-u', testData.username, '-f', 'path/to/key.json', '--json'])
     .it('should throw an error when client id (-i) is not provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJsonError(ctx.stdout);
       expect(response.status).to.equal(1);
       expect(response.message).to.include('Missing required flag');
     });
@@ -247,7 +248,7 @@ describe('auth:jwt:grant', async () => {
     .stdout()
     .command(['auth:jwt:grant', '-u', testData.username, '-f', 'path/to/key.json', '-i', '123456INVALID', '--json'])
     .it('should throw an error when client id is invalid', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJsonError(ctx.stdout);
       expect(response.status).to.equal(1);
       expect(response.message).to.include('We encountered a JSON web token error');
     });
@@ -257,7 +258,7 @@ describe('auth:jwt:grant', async () => {
     .stdout()
     .command(['auth:jwt:grant', '-u', testData.username, '-i', '123456', '--json'])
     .it('should throw an error when private key file (-f) is not provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJsonError(ctx.stdout);
       expect(response.status).to.equal(1);
       expect(response.message).to.include('Missing required flag');
     });
@@ -267,7 +268,7 @@ describe('auth:jwt:grant', async () => {
     .stdout()
     .command(['auth:jwt:grant', '-u', testData.username, '-f', 'path/to/key.json', '-i', '123456', '--json'])
     .it('should not throw an error when the authorization already exists', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
     });
@@ -284,7 +285,7 @@ describe('auth:jwt:grant', async () => {
     .stdout()
     .command(['auth:jwt:grant', '-u', testData.username, '-f', 'path/to/key.json', '-i', '123456', '--json'])
     .it('should auth when in demo mode (SFDX_ENV=demo) and prompt is answered with yes', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.save.callCount).to.equal(1);
@@ -302,7 +303,7 @@ describe('auth:jwt:grant', async () => {
     .stdout()
     .command(['auth:jwt:grant', '-u', testData.username, '-f', 'path/to/key.json', '-i', '123456', '--json'])
     .it('should do nothing when in demo mode (SFDX_ENV=demo) and prompt is answered with no', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal({});
       expect(authInfoStub.save.callCount).to.equal(0);
@@ -319,7 +320,7 @@ describe('auth:jwt:grant', async () => {
     .stdout()
     .command(['auth:jwt:grant', '-u', testData.username, '-f', 'path/to/key.json', '-i', '123456', '--json', '-p'])
     .it('should ignore prompt when in demo mode (SFDX_ENV=demo) and -p is provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.save.callCount).to.equal(1);

--- a/test/commands/auth/list.nut.ts
+++ b/test/commands/auth/list.nut.ts
@@ -7,9 +7,9 @@
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString, getString } from '@salesforce/ts-types';
+import { ensureString } from '@salesforce/ts-types';
 import { Authorization } from '@salesforce/core';
-import { Result, expectUrlToExist, expectOrgIdToExist, expectAccessTokenToExist } from '../../testHelper';
+import { expectUrlToExist, expectOrgIdToExist, expectAccessTokenToExist } from '../../testHelper';
 
 describe('auth:list NUTs', () => {
   let testSession: TestSession;
@@ -25,11 +25,11 @@ describe('auth:list NUTs', () => {
   });
 
   after(async () => {
-    await testSession.clean();
+    await testSession?.clean();
   });
 
   it('should list auth files (json)', () => {
-    const json = execCmd('auth:list --json', { ensureExitCode: 0 }).jsonOutput as Result<Authorization[]>;
+    const json = execCmd<Authorization[]>('auth:list --json', { ensureExitCode: 0 }).jsonOutput;
     const auth = json.result[0];
     expectAccessTokenToExist(auth);
     expectOrgIdToExist(auth);
@@ -38,8 +38,7 @@ describe('auth:list NUTs', () => {
   });
 
   it('should list auth files (human readable)', () => {
-    const result = execCmd('auth:list', { ensureExitCode: 0 });
-    const output = getString(result, 'shellOutput.stdout');
+    const output = execCmd('auth:list', { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.include(username);
     expect(output).to.include('jwt');
   });

--- a/test/commands/auth/list.nut.ts
+++ b/test/commands/auth/list.nut.ts
@@ -11,18 +11,21 @@ import { ensureString, getString } from '@salesforce/ts-types';
 import { Authorization } from '@salesforce/core';
 import { Result, expectPropsToExist, scrubSecrets } from '../../testHelper';
 
-let testSession: TestSession;
-
 describe('auth:list NUTs', () => {
+  let testSession: TestSession;
   let username: string;
 
-  before('ensure required environment variables exist', () => {
+  before('prepare session and ensure environment variables', () => {
     const env = new Env();
     ensureString(env.getString('TESTKIT_JWT_KEY'));
     ensureString(env.getString('TESTKIT_JWT_CLIENT_ID'));
     ensureString(env.getString('TESTKIT_HUB_INSTANCE'));
     username = ensureString(env.getString('TESTKIT_HUB_USERNAME'));
     testSession = TestSession.create({});
+  });
+
+  after(async () => {
+    await testSession.clean();
   });
 
   it('should list auth files (json)', () => {
@@ -49,8 +52,4 @@ describe('auth:list NUTs', () => {
         `       ${username}  00DB0000000EfT0MAK  https://gs0-dev-hub.my.salesforce.com  jwt\n`
     );
   });
-});
-
-after(async () => {
-  await testSession?.clean();
 });

--- a/test/commands/auth/list.nut.ts
+++ b/test/commands/auth/list.nut.ts
@@ -45,11 +45,9 @@ describe('auth:list NUTs', () => {
   it('should list auth files (human readable)', () => {
     const result = execCmd('auth:list', { ensureExitCode: 0 });
     const output = getString(result, 'shellOutput.stdout');
-    expect(output).to.equal(
-      '=== authenticated orgs\n' +
-        'ALIAS  USERNAME                         ORG ID              INSTANCE URL                           OAUTH METHOD\n' +
-        '─────  ───────────────────────────────  ──────────────────  ─────────────────────────────────────  ────────────\n' +
-        `       ${username}  00DB0000000EfT0MAK  https://gs0-dev-hub.my.salesforce.com  jwt\n`
-    );
+    expect(output).to.include(username);
+    expect(output).to.include('00DB0000000EfT0MAK');
+    expect(output).to.include('https://gs0-dev-hub.my.salesforce.com');
+    expect(output).to.include('jwt');
   });
 });

--- a/test/commands/auth/list.nut.ts
+++ b/test/commands/auth/list.nut.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { Env } from '@salesforce/kit';
+import { ensureString } from '@salesforce/ts-types';
+import { AuthorizationResult, expectAccessTokenToExist, scrubAccessTokens } from '../../testHelper';
+
+let testSession: TestSession;
+
+describe('auth:list NUTs', () => {
+  before('ensure required environment variables exist', () => {
+    const env = new Env();
+    ensureString(env.getString('TESTKIT_JWT_KEY'));
+    ensureString(env.getString('TESTKIT_JWT_CLIENT_ID'));
+    ensureString(env.getString('TESTKIT_HUB_INSTANCE'));
+    ensureString(env.getString('TESTKIT_HUB_USERNAME'));
+    testSession = TestSession.create({});
+  });
+
+  it('should list auth files (json)', () => {
+    const json = execCmd('auth:list --json', { ensureExitCode: 0 }).jsonOutput as AuthorizationResult;
+    expectAccessTokenToExist(json.result[0]);
+    const auths = scrubAccessTokens(json.result);
+    expect(auths).to.deep.equal([
+      {
+        instanceUrl: 'https://gs0-dev-hub.my.salesforce.com',
+        oauthMethod: 'jwt',
+        orgId: '00DB0000000EfT0MAK',
+        username: 'admin@integrationtesthubgs0.org',
+      },
+    ]);
+  });
+
+  it('should list auth files (human readable)', () => {
+    const output = execCmd('auth:list', { ensureExitCode: 0 }).shellOutput.stdout;
+    expect(output).to.equal(
+      '=== authenticated orgs\n' +
+        'ALIAS  USERNAME                         ORG ID              INSTANCE URL                           OAUTH METHOD\n' +
+        '─────  ───────────────────────────────  ──────────────────  ─────────────────────────────────────  ────────────\n' +
+        '       admin@integrationtesthubgs0.org  00DB0000000EfT0MAK  https://gs0-dev-hub.my.salesforce.com  jwt\n'
+    );
+  });
+});
+
+after(async () => {
+  await testSession?.clean();
+});

--- a/test/commands/auth/list.nut.ts
+++ b/test/commands/auth/list.nut.ts
@@ -7,7 +7,7 @@
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString } from '@salesforce/ts-types';
+import { ensureString, getString } from '@salesforce/ts-types';
 import { Authorization } from '@salesforce/core';
 import { expectUrlToExist, expectOrgIdToExist, expectAccessTokenToExist } from '../../testHelper';
 
@@ -38,7 +38,8 @@ describe('auth:list NUTs', () => {
   });
 
   it('should list auth files (human readable)', () => {
-    const output = execCmd('auth:list', { ensureExitCode: 0 }).shellOutput.stdout;
+    const result = execCmd('auth:list', { ensureExitCode: 0 });
+    const output = getString(result, 'shellOutput.stdout');
     expect(output).to.include(username);
     expect(output).to.include('jwt');
   });

--- a/test/commands/auth/list.nut.ts
+++ b/test/commands/auth/list.nut.ts
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
 import { ensureString, getString } from '@salesforce/ts-types';
 import { Authorization } from '@salesforce/core';
-import { Result, expectPropsToExist, scrubSecrets } from '../../testHelper';
+import { Result, expectUrlToExist, expectOrgIdToExist, expectAccessTokenToExist } from '../../testHelper';
 
 describe('auth:list NUTs', () => {
   let testSession: TestSession;
@@ -30,24 +30,17 @@ describe('auth:list NUTs', () => {
 
   it('should list auth files (json)', () => {
     const json = execCmd('auth:list --json', { ensureExitCode: 0 }).jsonOutput as Result<Authorization[]>;
-    expectPropsToExist(json.result[0], 'accessToken');
-    const auths = scrubSecrets(json.result);
-    expect(auths).to.deep.equal([
-      {
-        instanceUrl: 'https://gs0-dev-hub.my.salesforce.com',
-        oauthMethod: 'jwt',
-        orgId: '00DB0000000EfT0MAK',
-        username,
-      },
-    ]);
+    const auth = json.result[0];
+    expectAccessTokenToExist(auth);
+    expectOrgIdToExist(auth);
+    expectUrlToExist(auth, 'instanceUrl');
+    expect(auth.username).to.equal(username);
   });
 
   it('should list auth files (human readable)', () => {
     const result = execCmd('auth:list', { ensureExitCode: 0 });
     const output = getString(result, 'shellOutput.stdout');
     expect(output).to.include(username);
-    expect(output).to.include('00DB0000000EfT0MAK');
-    expect(output).to.include('https://gs0-dev-hub.my.salesforce.com');
     expect(output).to.include('jwt');
   });
 });

--- a/test/commands/auth/list.nut.ts
+++ b/test/commands/auth/list.nut.ts
@@ -8,30 +8,33 @@ import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
 import { ensureString, getString } from '@salesforce/ts-types';
-import { AuthorizationResult, expectAccessTokenToExist, scrubAccessTokens } from '../../testHelper';
+import { Authorization } from '@salesforce/core';
+import { Result, expectPropsToExist, scrubSecrets } from '../../testHelper';
 
 let testSession: TestSession;
 
 describe('auth:list NUTs', () => {
+  let username: string;
+
   before('ensure required environment variables exist', () => {
     const env = new Env();
     ensureString(env.getString('TESTKIT_JWT_KEY'));
     ensureString(env.getString('TESTKIT_JWT_CLIENT_ID'));
     ensureString(env.getString('TESTKIT_HUB_INSTANCE'));
-    ensureString(env.getString('TESTKIT_HUB_USERNAME'));
+    username = ensureString(env.getString('TESTKIT_HUB_USERNAME'));
     testSession = TestSession.create({});
   });
 
   it('should list auth files (json)', () => {
-    const json = execCmd('auth:list --json', { ensureExitCode: 0 }).jsonOutput as AuthorizationResult;
-    expectAccessTokenToExist(json.result[0]);
-    const auths = scrubAccessTokens(json.result);
+    const json = execCmd('auth:list --json', { ensureExitCode: 0 }).jsonOutput as Result<Authorization[]>;
+    expectPropsToExist(json.result[0], 'accessToken');
+    const auths = scrubSecrets(json.result);
     expect(auths).to.deep.equal([
       {
         instanceUrl: 'https://gs0-dev-hub.my.salesforce.com',
         oauthMethod: 'jwt',
         orgId: '00DB0000000EfT0MAK',
-        username: 'admin@integrationtesthubgs0.org',
+        username,
       },
     ]);
   });
@@ -43,7 +46,7 @@ describe('auth:list NUTs', () => {
       '=== authenticated orgs\n' +
         'ALIAS  USERNAME                         ORG ID              INSTANCE URL                           OAUTH METHOD\n' +
         '─────  ───────────────────────────────  ──────────────────  ─────────────────────────────────────  ────────────\n' +
-        '       admin@integrationtesthubgs0.org  00DB0000000EfT0MAK  https://gs0-dev-hub.my.salesforce.com  jwt\n'
+        `       ${username}  00DB0000000EfT0MAK  https://gs0-dev-hub.my.salesforce.com  jwt\n`
     );
   });
 });

--- a/test/commands/auth/list.nut.ts
+++ b/test/commands/auth/list.nut.ts
@@ -7,7 +7,7 @@
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString } from '@salesforce/ts-types';
+import { ensureString, getString } from '@salesforce/ts-types';
 import { AuthorizationResult, expectAccessTokenToExist, scrubAccessTokens } from '../../testHelper';
 
 let testSession: TestSession;
@@ -37,7 +37,8 @@ describe('auth:list NUTs', () => {
   });
 
   it('should list auth files (human readable)', () => {
-    const output = execCmd('auth:list', { ensureExitCode: 0 }).shellOutput.stdout;
+    const result = execCmd('auth:list', { ensureExitCode: 0 });
+    const output = getString(result, 'shellOutput.stdout');
     expect(output).to.equal(
       '=== authenticated orgs\n' +
         'ALIAS  USERNAME                         ORG ID              INSTANCE URL                           OAUTH METHOD\n' +

--- a/test/commands/auth/list.test.ts
+++ b/test/commands/auth/list.test.ts
@@ -6,9 +6,10 @@
  */
 
 import { $$, expect, test } from '@salesforce/command/lib/test';
-import { Aliases, AuthInfo, AuthInfoConfig } from '@salesforce/core';
+import { Aliases, AuthInfo, AuthInfoConfig, Authorization } from '@salesforce/core';
 import { MockTestOrgData } from '@salesforce/core/lib/testSetup';
 import { StubbedType, stubInterface, stubMethod } from '@salesforce/ts-sinon';
+import { parseJson } from '../../testHelper';
 
 describe('auth:list', async () => {
   const testData = new MockTestOrgData();
@@ -47,7 +48,7 @@ describe('auth:list', async () => {
     .stdout()
     .command(['auth:list', '--json'])
     .it('should show auth files', (ctx) => {
-      const auths = JSON.parse(ctx.stdout).result;
+      const auths = parseJson<Authorization[]>(ctx.stdout).result;
       expect(auths[0].alias).to.equal('TestAlias');
       expect(auths[0].username).to.equal(testData.username);
       expect(auths[0].instanceUrl).to.equal(testData.instanceUrl);
@@ -60,7 +61,7 @@ describe('auth:list', async () => {
     .stdout()
     .command(['auth:list', '--json'])
     .it('should show files with auth errors', (ctx) => {
-      const auths = JSON.parse(ctx.stdout).result;
+      const auths = parseJson<Authorization[]>(ctx.stdout).result;
       expect(auths[0].alias).to.equal('TestAlias');
       expect(auths[0].username).to.equal(testData.username);
       expect(auths[0].instanceUrl).to.equal(testData.instanceUrl);

--- a/test/commands/auth/logout.nut.ts
+++ b/test/commands/auth/logout.nut.ts
@@ -7,9 +7,8 @@
 import { execCmd, TestSession, prepareForJwt } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString, getString } from '@salesforce/ts-types';
+import { ensureString } from '@salesforce/ts-types';
 import { Authorization } from '@salesforce/core';
-import { Result } from '../../testHelper';
 
 describe('auth:logout NUTs', () => {
   const env = new Env();
@@ -30,7 +29,7 @@ describe('auth:logout NUTs', () => {
   });
 
   after(async () => {
-    await testSession.clean();
+    await testSession?.clean();
   });
 
   beforeEach(() => {
@@ -45,19 +44,18 @@ describe('auth:logout NUTs', () => {
       result: [username],
     });
 
-    const list = execCmd('auth:list --json', { ensureExitCode: 0 }).jsonOutput as Result<Authorization[]>;
+    const list = execCmd<Authorization[]>('auth:list --json', { ensureExitCode: 0 }).jsonOutput;
     const found = !!list.result.find((r) => r.username === username);
     expect(found).to.be.false;
   });
 
   it('should remove the org specified by the -u flag (human readable)', () => {
-    const result = execCmd(`auth:logout -p -u ${username}`, { ensureExitCode: 0 });
-    const output = getString(result, 'shellOutput.stdout');
+    const output = execCmd(`auth:logout -p -u ${username}`, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.include(`Successfully logged out of orgs: ${username}`);
   });
 
   it('should fail if there is no default org and the -u flag is not specified (json)', () => {
-    const json = execCmd('auth:logout -p --json', { ensureExitCode: 1 }).jsonOutput as { name: string };
+    const json = execCmd<{ name: string }>('auth:logout -p --json', { ensureExitCode: 1 }).jsonOutput;
     expect(json.name).to.equal('NoOrgFound');
   });
 
@@ -70,9 +68,8 @@ describe('auth:logout NUTs', () => {
     });
 
     // we expect the config for defaultusername to be cleared out after the logout
-    const configGet = execCmd('config:get defaultusername --json', { ensureExitCode: 0 }).jsonOutput as {
-      result: Array<{ key: string }>;
-    };
+    const configGet = execCmd<Array<{ key: string }>>('config:get defaultusername --json', { ensureExitCode: 0 })
+      .jsonOutput;
     expect(configGet.result).to.deep.equal([{ key: 'defaultusername' }]);
   });
 });

--- a/test/commands/auth/logout.nut.ts
+++ b/test/commands/auth/logout.nut.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { Env } from '@salesforce/kit';
+import { ensureString } from '@salesforce/ts-types';
+
+let testSession: TestSession;
+
+describe('auth:logout NUTs', () => {
+  const env = new Env();
+
+  before('ensure required environment variables exist', () => {
+    ensureString(env.getString('TESTKIT_JWT_KEY'));
+    ensureString(env.getString('TESTKIT_JWT_CLIENT_ID'));
+    ensureString(env.getString('TESTKIT_HUB_INSTANCE'));
+    ensureString(env.getString('TESTKIT_HUB_USERNAME'));
+  });
+
+  beforeEach(() => {
+    testSession = TestSession.create({});
+  });
+
+  afterEach(async () => {
+    await testSession.clean();
+  });
+
+  it('should remove the org specified by the -u flag (json)', () => {
+    const username = env.getString('TESTKIT_HUB_USERNAME');
+    const json = execCmd(`auth:logout -p -u ${username} --json`, { ensureExitCode: 0 }).jsonOutput;
+    expect(json).to.deep.equal({
+      status: 0,
+      result: [username],
+    });
+  });
+
+  it('should remove the org specified by the -u flag (human readable)', () => {
+    const username = env.getString('TESTKIT_HUB_USERNAME');
+    const output = execCmd(`auth:logout -p -u ${username}`, { ensureExitCode: 0 }).shellOutput.stdout;
+    expect(output).to.equal(`Successfully logged out of orgs: ${username}\n`);
+  });
+
+  it('should fail if there is no default org and the -u flag is not specified (json)', () => {
+    const json = execCmd('auth:logout -p --json', { ensureExitCode: 1 }).jsonOutput as { name: string };
+    expect(json.name).to.equal('NoOrgFound');
+  });
+
+  it('should remove the default username if the -u flag is not specified (json)', () => {
+    const username = env.getString('TESTKIT_HUB_USERNAME');
+    execCmd(`config:set defaultusername=${username} --global`, { ensureExitCode: 0 });
+    const json = execCmd('auth:logout -p --json', { ensureExitCode: 0 }).jsonOutput;
+    expect(json).to.deep.equal({
+      status: 0,
+      result: [username],
+    });
+  });
+});

--- a/test/commands/auth/logout.nut.ts
+++ b/test/commands/auth/logout.nut.ts
@@ -4,33 +4,39 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { execCmd, TestSession, prepareForJwt } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
 import { ensureString, getString } from '@salesforce/ts-types';
 
-let testSession: TestSession;
-
 describe('auth:logout NUTs', () => {
   const env = new Env();
+  let testSession: TestSession;
+  let jwtKey: string;
+  let username: string;
+  let instanceUrl: string;
+  let clientId: string;
 
-  before('ensure required environment variables exist', () => {
+  before('prepare session and ensure environment variables', () => {
+    username = ensureString(env.getString('TESTKIT_HUB_USERNAME'));
+    instanceUrl = ensureString(env.getString('TESTKIT_HUB_INSTANCE'));
+    clientId = ensureString(env.getString('TESTKIT_JWT_CLIENT_ID'));
     ensureString(env.getString('TESTKIT_JWT_KEY'));
-    ensureString(env.getString('TESTKIT_JWT_CLIENT_ID'));
-    ensureString(env.getString('TESTKIT_HUB_INSTANCE'));
-    ensureString(env.getString('TESTKIT_HUB_USERNAME'));
+
+    testSession = TestSession.create({ authStrategy: 'NONE' });
+    jwtKey = prepareForJwt(testSession.homeDir);
   });
 
-  beforeEach(() => {
-    testSession = TestSession.create({});
-  });
-
-  afterEach(async () => {
+  after(async () => {
     await testSession.clean();
   });
 
+  beforeEach(() => {
+    const command = `auth:jwt:grant -d -u ${username} -i ${clientId} -f ${jwtKey} -r ${instanceUrl} --json`;
+    execCmd(command, { ensureExitCode: 0 });
+  });
+
   it('should remove the org specified by the -u flag (json)', () => {
-    const username = env.getString('TESTKIT_HUB_USERNAME');
     const json = execCmd(`auth:logout -p -u ${username} --json`, { ensureExitCode: 0 }).jsonOutput;
     expect(json).to.deep.equal({
       status: 0,
@@ -39,7 +45,6 @@ describe('auth:logout NUTs', () => {
   });
 
   it('should remove the org specified by the -u flag (human readable)', () => {
-    const username = env.getString('TESTKIT_HUB_USERNAME');
     const result = execCmd(`auth:logout -p -u ${username}`, { ensureExitCode: 0 });
     const output = getString(result, 'shellOutput.stdout');
     expect(output).to.equal(`Successfully logged out of orgs: ${username}\n`);
@@ -51,7 +56,6 @@ describe('auth:logout NUTs', () => {
   });
 
   it('should remove the default username if the -u flag is not specified (json)', () => {
-    const username = env.getString('TESTKIT_HUB_USERNAME');
     execCmd(`config:set defaultusername=${username} --global`, { ensureExitCode: 0 });
     const json = execCmd('auth:logout -p --json', { ensureExitCode: 0 }).jsonOutput;
     expect(json).to.deep.equal({

--- a/test/commands/auth/logout.nut.ts
+++ b/test/commands/auth/logout.nut.ts
@@ -8,6 +8,8 @@ import { execCmd, TestSession, prepareForJwt } from '@salesforce/cli-plugins-tes
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
 import { ensureString, getString } from '@salesforce/ts-types';
+import { Authorization } from '@salesforce/core';
+import { Result } from '../../testHelper';
 
 describe('auth:logout NUTs', () => {
   const env = new Env();
@@ -42,12 +44,16 @@ describe('auth:logout NUTs', () => {
       status: 0,
       result: [username],
     });
+
+    const list = execCmd('auth:list --json', { ensureExitCode: 0 }).jsonOutput as Result<Authorization[]>;
+    const found = !!list.result.find((r) => r.username === username);
+    expect(found).to.be.false;
   });
 
   it('should remove the org specified by the -u flag (human readable)', () => {
     const result = execCmd(`auth:logout -p -u ${username}`, { ensureExitCode: 0 });
     const output = getString(result, 'shellOutput.stdout');
-    expect(output).to.equal(`Successfully logged out of orgs: ${username}\n`);
+    expect(output).to.include(`Successfully logged out of orgs: ${username}`);
   });
 
   it('should fail if there is no default org and the -u flag is not specified (json)', () => {
@@ -62,5 +68,11 @@ describe('auth:logout NUTs', () => {
       status: 0,
       result: [username],
     });
+
+    // we expect the config for defaultusername to be cleared out after the logout
+    const configGet = execCmd('config:get defaultusername --json', { ensureExitCode: 0 }).jsonOutput as {
+      result: Array<{ key: string }>;
+    };
+    expect(configGet.result).to.deep.equal([{ key: 'defaultusername' }]);
   });
 });

--- a/test/commands/auth/logout.nut.ts
+++ b/test/commands/auth/logout.nut.ts
@@ -7,7 +7,7 @@
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString } from '@salesforce/ts-types';
+import { ensureString, getString } from '@salesforce/ts-types';
 
 let testSession: TestSession;
 
@@ -40,7 +40,8 @@ describe('auth:logout NUTs', () => {
 
   it('should remove the org specified by the -u flag (human readable)', () => {
     const username = env.getString('TESTKIT_HUB_USERNAME');
-    const output = execCmd(`auth:logout -p -u ${username}`, { ensureExitCode: 0 }).shellOutput.stdout;
+    const result = execCmd(`auth:logout -p -u ${username}`, { ensureExitCode: 0 });
+    const output = getString(result, 'shellOutput.stdout');
     expect(output).to.equal(`Successfully logged out of orgs: ${username}\n`);
   });
 

--- a/test/commands/auth/logout.nut.ts
+++ b/test/commands/auth/logout.nut.ts
@@ -7,7 +7,7 @@
 import { execCmd, TestSession, prepareForJwt } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString } from '@salesforce/ts-types';
+import { ensureString, getString } from '@salesforce/ts-types';
 import { Authorization } from '@salesforce/core';
 
 describe('auth:logout NUTs', () => {
@@ -74,7 +74,8 @@ describe('auth:logout NUTs', () => {
   });
 
   it('should remove the org specified by the -u flag (human readable)', () => {
-    const output = execCmd(`auth:logout -p -u ${username}`, { ensureExitCode: 0 }).shellOutput.stdout;
+    const result = execCmd(`auth:logout -p -u ${username}`, { ensureExitCode: 0 });
+    const output = getString(result, 'shellOutput.stdout');
     expect(output).to.include(`Successfully logged out of orgs: ${username}`);
   });
 

--- a/test/commands/auth/logout.test.ts
+++ b/test/commands/auth/logout.test.ts
@@ -164,9 +164,6 @@ describe('auth:logout', () => {
       expect(authInfoConfigStub.unlink.callCount).to.equal(1);
       expect(spies.get('aliasesUnset').callCount).to.equal(1);
       expect(spies.get('aliasesUnset').args[0]).to.deep.equal(['TestAlias']);
-      // expect the Config.unset to be called twice for the global config and local config
-      expect(spies.get('configUnset').callCount).to.equal(2);
-      expect(spies.get('configUnset').args[0]).to.deep.equal([Config.DEFAULT_USERNAME]);
     });
 
   test
@@ -188,9 +185,6 @@ describe('auth:logout', () => {
       expect(authInfoConfigStub.unlink.callCount).to.equal(1);
       expect(spies.get('aliasesUnset').callCount).to.equal(1);
       expect(spies.get('aliasesUnset').args[0]).to.deep.equal(['TestAlias']);
-      // expect the Config.unset to be called zero since the
-      // specified username is different that the defaultusername
-      expect(spies.get('configUnset').callCount).to.equal(0);
     });
 
   test
@@ -216,8 +210,6 @@ describe('auth:logout', () => {
       expect(authInfoConfigStub.unlink.callCount).to.equal(3);
       expect(spies.get('aliasesUnset').callCount).to.equal(3);
       expect(spies.get('aliasesUnset').args).to.deep.equal([['TestAlias'], ['TestAlias1'], ['TestAlias2']]);
-      // expect the Config.unset to be called twice for the global config and local config
-      expect(spies.get('configUnset').callCount).to.equal(2);
     });
 
   test
@@ -244,8 +236,6 @@ describe('auth:logout', () => {
       expect(spies.get('authInfoClearCache').callCount).to.equal(3);
       expect(authInfoConfigStub.unlink.callCount).to.equal(3);
       expect(spies.get('aliasesUnset').callCount).to.equal(3);
-      // expect the Config.unset to be called twice for the global config and local config
-      expect(spies.get('configUnset').callCount).to.equal(2);
     });
 
   test
@@ -304,7 +294,6 @@ describe('auth:logout', () => {
       expect(spies.get('authInfoClearCache').callCount).to.equal(0);
       expect(authInfoConfigStub.unlink.callCount).to.equal(0);
       expect(spies.get('aliasesUnset').callCount).to.equal(0);
-      expect(spies.get('configUnset').callCount).to.equal(0);
     });
 
   test
@@ -320,8 +309,6 @@ describe('auth:logout', () => {
       const response = parseJson<string[]>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal([testData.username]);
-      // expect the Config.unset to be called twice for the global config and local config
-      expect(spies.get('configUnset').callCount).to.equal(2);
     });
 
   test
@@ -338,14 +325,6 @@ describe('auth:logout', () => {
       const response = parseJson<string[]>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal([testData.username]);
-      // expect callCount twice for each, 4 times total
-      expect(spies.get('configUnset').callCount).to.equal(4);
-      expect(spies.get('configUnset').args).to.deep.equal([
-        [Config.DEFAULT_DEV_HUB_USERNAME],
-        [Config.DEFAULT_USERNAME],
-        [Config.DEFAULT_DEV_HUB_USERNAME],
-        [Config.DEFAULT_USERNAME],
-      ]);
     });
 
   test
@@ -361,9 +340,6 @@ describe('auth:logout', () => {
       const response = parseJson<string[]>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal([testData.username]);
-      // expect the Config.unset to be called twice for the global config and local config
-      expect(spies.get('configUnset').callCount).to.equal(2);
-      expect(spies.get('configUnset').args[0]).to.deep.equal([Config.DEFAULT_USERNAME]);
     });
 
   test

--- a/test/commands/auth/sfdxurl/store.nut.ts
+++ b/test/commands/auth/sfdxurl/store.nut.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { Env } from '@salesforce/kit';
+import { ensureString } from '@salesforce/ts-types';
+import { AuthorizationResult, expectAccessTokenToExist, scrubAccessTokens } from '../../../testHelper';
+
+let testSession: TestSession;
+
+describe('auth:sfdxurl:store NUTs', () => {
+  const env = new Env();
+
+  before('ensure required environment variables exist', () => {
+    ensureString(env.getString('TESTKIT_AUTH_URL'));
+
+    // Unset these env vars so that testkit doesn't default to jwt auth
+    env.unset('TESTKIT_JWT_KEY');
+    env.unset('TESTKIT_JWT_CLIENT_ID');
+    env.unset('TESTKIT_HUB_INSTANCE');
+    env.unset('TESTKIT_HUB_USERNAME');
+  });
+
+  beforeEach(() => {
+    testSession = TestSession.create({});
+  });
+
+  afterEach(async () => {
+    await testSession.clean();
+  });
+
+  it('should authorize an org using sfdxurl', () => {
+    // TestSession does sfdxurl auth for us, so we just want to make sure that the auth file exists
+    const json = execCmd('auth:list --json', { ensureExitCode: 0 }).jsonOutput as AuthorizationResult;
+    expectAccessTokenToExist(json.result[0]);
+    const auths = scrubAccessTokens(json.result);
+    expect(auths).to.deep.equal([
+      {
+        instanceUrl: 'https://gs0-dev-hub.my.salesforce.com',
+        oauthMethod: 'web',
+        orgId: '00DB0000000EfT0MAK',
+        username: 'admin@integrationtesthubgs0.org',
+      },
+    ]);
+  });
+});

--- a/test/commands/auth/sfdxurl/store.nut.ts
+++ b/test/commands/auth/sfdxurl/store.nut.ts
@@ -7,7 +7,7 @@
 import { execCmd, TestSession, prepareForAuthUrl } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString } from '@salesforce/ts-types';
+import { ensureString, getString } from '@salesforce/ts-types';
 import { AuthFields } from '@salesforce/core';
 import {
   expectPropsToExist,
@@ -52,7 +52,8 @@ describe('auth:sfdxurl:store NUTs', () => {
 
   it('should authorize an org using sfdxurl (human readable)', () => {
     const command = `auth:sfdxurl:store -d -f ${authUrl}`;
-    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+    const result = execCmd(command, { ensureExitCode: 0 });
+    const output = getString(result, 'shellOutput.stdout');
     expect(output).to.include(`Successfully authorized ${username} with org ID`);
   });
 });

--- a/test/commands/auth/sfdxurl/store.nut.ts
+++ b/test/commands/auth/sfdxurl/store.nut.ts
@@ -7,10 +7,9 @@
 import { execCmd, TestSession, prepareForAuthUrl } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
-import { ensureString, getString } from '@salesforce/ts-types';
+import { ensureString } from '@salesforce/ts-types';
 import { AuthFields } from '@salesforce/core';
 import {
-  Result,
   expectPropsToExist,
   expectAccessTokenToExist,
   expectOrgIdToExist,
@@ -32,7 +31,7 @@ describe('auth:sfdxurl:store NUTs', () => {
   });
 
   after(async () => {
-    await testSession.clean();
+    await testSession?.clean();
   });
 
   afterEach(() => {
@@ -41,7 +40,7 @@ describe('auth:sfdxurl:store NUTs', () => {
 
   it('should authorize an org using sfdxurl (json)', () => {
     const command = `auth:sfdxurl:store -d -f ${authUrl} --json`;
-    const json = execCmd(command, { ensureExitCode: 0 }).jsonOutput as Result<AuthFields>;
+    const json = execCmd<AuthFields>(command, { ensureExitCode: 0 }).jsonOutput;
 
     expectPropsToExist(json.result, 'refreshToken');
     expectAccessTokenToExist(json.result);
@@ -53,8 +52,7 @@ describe('auth:sfdxurl:store NUTs', () => {
 
   it('should authorize an org using sfdxurl (human readable)', () => {
     const command = `auth:sfdxurl:store -d -f ${authUrl}`;
-    const result = execCmd(command, { ensureExitCode: 0 });
-    const output = getString(result, 'shellOutput.stdout', '');
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.include(`Successfully authorized ${username} with org ID`);
   });
 });

--- a/test/commands/auth/sfdxurl/store.nut.ts
+++ b/test/commands/auth/sfdxurl/store.nut.ts
@@ -50,6 +50,6 @@ describe('auth:sfdxurl:store NUTs', () => {
     const command = `auth:sfdxurl:store -d -f ${authUrl}`;
     const result = execCmd(command, { ensureExitCode: 0 });
     const output = getString(result, 'shellOutput.stdout', '');
-    expect(output).to.equal(`Successfully authorized ${username} with org ID 00DB0000000EfT0MAK\n`);
+    expect(output).to.include(`Successfully authorized ${username} with org ID 00DB0000000EfT0MAK`);
   });
 });

--- a/test/commands/auth/sfdxurl/store.nut.ts
+++ b/test/commands/auth/sfdxurl/store.nut.ts
@@ -9,7 +9,13 @@ import { expect } from 'chai';
 import { Env } from '@salesforce/kit';
 import { ensureString, getString } from '@salesforce/ts-types';
 import { AuthFields } from '@salesforce/core';
-import { Result, expectPropsToExist, scrubSecrets } from '../../../testHelper';
+import {
+  Result,
+  expectPropsToExist,
+  expectAccessTokenToExist,
+  expectOrgIdToExist,
+  expectUrlToExist,
+} from '../../../testHelper';
 
 let testSession: TestSession;
 
@@ -36,14 +42,13 @@ describe('auth:sfdxurl:store NUTs', () => {
   it('should authorize an org using sfdxurl (json)', () => {
     const command = `auth:sfdxurl:store -d -f ${authUrl} --json`;
     const json = execCmd(command, { ensureExitCode: 0 }).jsonOutput as Result<AuthFields>;
-    expectPropsToExist(json.result, 'accessToken', 'refreshToken');
-    const auths = scrubSecrets(json.result);
-    expect(auths).to.deep.equal({
-      loginUrl: 'https://gs0-dev-hub.my.salesforce.com',
-      instanceUrl: 'https://gs0-dev-hub.my.salesforce.com',
-      orgId: '00DB0000000EfT0MAK',
-      username,
-    });
+
+    expectPropsToExist(json.result, 'refreshToken');
+    expectAccessTokenToExist(json.result);
+    expectOrgIdToExist(json.result);
+    expectUrlToExist(json.result, 'instanceUrl');
+    expectUrlToExist(json.result, 'loginUrl');
+    expect(json.result.username).to.equal(username);
   });
 
   it('should authorize an org using sfdxurl (human readable)', () => {

--- a/test/commands/auth/sfdxurl/store.nut.ts
+++ b/test/commands/auth/sfdxurl/store.nut.ts
@@ -55,6 +55,6 @@ describe('auth:sfdxurl:store NUTs', () => {
     const command = `auth:sfdxurl:store -d -f ${authUrl}`;
     const result = execCmd(command, { ensureExitCode: 0 });
     const output = getString(result, 'shellOutput.stdout', '');
-    expect(output).to.include(`Successfully authorized ${username} with org ID 00DB0000000EfT0MAK`);
+    expect(output).to.include(`Successfully authorized ${username} with org ID`);
   });
 });

--- a/test/commands/auth/sfdxurl/store.test.ts
+++ b/test/commands/auth/sfdxurl/store.test.ts
@@ -10,6 +10,7 @@ import { AuthFields, AuthInfo, fs } from '@salesforce/core';
 import { MockTestOrgData } from '@salesforce/core/lib/testSetup';
 import { StubbedType, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { UX } from '@salesforce/command';
+import { parseJson } from '../../../testHelper';
 
 interface Options {
   authInfoCreateFails?: boolean;
@@ -51,7 +52,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '--json'])
     .it('should return auth fields', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(response.result.username).to.equal(testData.username);
@@ -62,7 +63,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '-a', 'MyAlias', '--json'])
     .it('should set alias when -a is provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.callCount).to.equal(1);
@@ -73,7 +74,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '-a', 'MyAlias', '-s', '--json'])
     .it('should set defaultusername to alias when -s and -a are provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.args[0]).to.deep.equal(['MyAlias']);
@@ -91,7 +92,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '-s', '--json'])
     .it('should set defaultusername to username when -s is provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.callCount).to.equal(0);
@@ -109,7 +110,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '-a', 'MyAlias', '-d', '--json'])
     .it('should set defaultdevhubusername to alias when -d and -a are provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.args[0]).to.deep.equal(['MyAlias']);
@@ -127,7 +128,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '-d', '--json'])
     .it('should set defaultdevhubusername to username when -d is provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.callCount).to.equal(0);
@@ -144,7 +145,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '-d', '-s', '--json'])
     .it('should set defaultusername and defaultdevhubusername to username when -d and -s are provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.callCount).to.equal(0);
@@ -162,7 +163,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '-d', '-s', '-a', 'MyAlias', '--json'])
     .it('should set defaultusername and defaultdevhubusername to alias when -a, -d, and -s are provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.setAlias.args[0]).to.deep.equal(['MyAlias']);
@@ -187,7 +188,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '--json'])
     .it('should auth when in demo mode (SFDX_ENV=demo) and prompt is answered with yes', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.save.callCount).to.equal(1);
@@ -205,7 +206,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '--json'])
     .it('should do nothing when in demo mode (SFDX_ENV=demo) and prompt is answered with no', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal({});
       expect(authInfoStub.save.callCount).to.equal(0);
@@ -222,7 +223,7 @@ describe('auth:sfdxurl:store', async () => {
     .stdout()
     .command(['auth:sfdxurl:store', '-f', 'path/to/key.txt', '--json', '-p'])
     .it('should ignore prompt when in demo mode (SFDX_ENV=demo) and -p is provided', (ctx) => {
-      const response = JSON.parse(ctx.stdout);
+      const response = parseJson<AuthFields>(ctx.stdout);
       expect(response.status).to.equal(0);
       expect(response.result).to.deep.equal(authFields);
       expect(authInfoStub.save.callCount).to.equal(1);

--- a/test/commands/auth/web/login.test.ts
+++ b/test/commands/auth/web/login.test.ts
@@ -97,7 +97,8 @@ describe('auth:web:login', () => {
     const login = await createNewLoginCommand();
     try {
       await login.run();
-    } catch (err) {
+    } catch (error) {
+      const err = error as SfdxError;
       expect(err.name).to.equal('DEVICE_WARNING');
     }
   });
@@ -130,7 +131,8 @@ describe('auth:web:login', () => {
       await login.run();
       assert(false, 'should throw error');
     } catch (e) {
-      expect(e.message).to.include('Invalid client credentials');
+      const err = e as SfdxError;
+      expect(err.message).to.include('Invalid client credentials');
     }
   });
 
@@ -140,7 +142,8 @@ describe('auth:web:login', () => {
       await login.run();
       assert(false, 'should throw error');
     } catch (e) {
-      expect(e.message).to.include('error!');
+      const err = e as SfdxError;
+      expect(err.message).to.include('error!');
     }
   });
 });

--- a/test/testHelper.ts
+++ b/test/testHelper.ts
@@ -36,7 +36,7 @@ export function expectOrgIdToExist(auth: AuthFields): void {
 
 export function expectUrlToExist(auth: AuthFields, urlKey: UrlKey): void {
   expect(auth[urlKey]).to.exist;
-  expect(auth[urlKey].startsWith('https://')).to.be.true;
+  expect(/^https*:\/\//.test(auth[urlKey])).to.be.true;
 }
 
 export function expectAccessTokenToExist(auth: AuthFields): void {

--- a/test/testHelper.ts
+++ b/test/testHelper.ts
@@ -13,6 +13,17 @@ export type AuthorizationResult = {
   result: Authorization[];
 };
 
+export type Result<T> = {
+  status: number;
+  result: T;
+};
+
+export type ErrorResult = {
+  status: number;
+  name: string;
+  message: string;
+};
+
 export function scrubAccessTokens(auths: Authorization[]): Authorization[] {
   auths.forEach((auth) => {
     delete auth.accessToken;
@@ -23,4 +34,12 @@ export function scrubAccessTokens(auths: Authorization[]): Authorization[] {
 export function expectAccessTokenToExist(auth: Authorization): void {
   expect(auth.accessToken).to.exist;
   expect(auth.accessToken).to.be.a('string');
+}
+
+export function parseJson<T = unknown>(jsonString: string): Result<T> {
+  return JSON.parse(jsonString) as Result<T>;
+}
+
+export function parseJsonError(jsonString: string): ErrorResult {
+  return JSON.parse(jsonString) as ErrorResult;
 }

--- a/test/testHelper.ts
+++ b/test/testHelper.ts
@@ -20,22 +20,28 @@ export type ErrorResult = {
   message: string;
 };
 
-export function scrubSecrets(auths: AuthFields | AuthFields[]): AuthFields | AuthFields[] {
-  const authsToScrub = Array.isArray(auths) ? auths : [auths];
-  authsToScrub.forEach((auth) => {
-    delete auth.accessToken;
-    delete auth.clientSecret;
-    delete auth.clientId;
-    delete auth.refreshToken;
-  });
-  return auths;
-}
+type UrlKey = Extract<keyof AuthFields, 'instanceUrl' | 'loginUrl'>;
 
 export function expectPropsToExist(auth: AuthFields, ...props: Array<keyof AuthFields>): void {
   props.forEach((prop) => {
     expect(auth[prop]).to.exist;
     expect(auth[prop]).to.be.a('string');
   });
+}
+
+export function expectOrgIdToExist(auth: AuthFields): void {
+  expect(auth.orgId).to.exist;
+  expect(auth.orgId.length).to.equal(18);
+}
+
+export function expectUrlToExist(auth: AuthFields, urlKey: UrlKey): void {
+  expect(auth[urlKey]).to.exist;
+  expect(auth[urlKey].startsWith('https://')).to.be.true;
+}
+
+export function expectAccessTokenToExist(auth: AuthFields): void {
+  expect(auth.accessToken).to.exist;
+  expect(auth.accessToken.startsWith(auth.orgId.substr(0, 15))).to.be.true;
 }
 
 export function parseJson<T = unknown>(jsonString: string): Result<T> {

--- a/test/testHelper.ts
+++ b/test/testHelper.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import { Authorization } from '@salesforce/core';
+
+export type AuthorizationResult = {
+  status: number;
+  result: Authorization[];
+};
+
+export function scrubAccessTokens(auths: Authorization[]): Authorization[] {
+  auths.forEach((auth) => {
+    delete auth.accessToken;
+  });
+  return auths;
+}
+
+export function expectAccessTokenToExist(auth: Authorization): void {
+  expect(auth.accessToken).to.exist;
+  expect(auth.accessToken).to.be.a('string');
+}

--- a/test/testHelper.ts
+++ b/test/testHelper.ts
@@ -6,16 +6,12 @@
  */
 
 import { expect } from 'chai';
-import { Authorization } from '@salesforce/core';
-
-export type AuthorizationResult = {
-  status: number;
-  result: Authorization[];
-};
+import { AuthFields } from '@salesforce/core';
+import { AnyJson } from '@salesforce/ts-types';
 
 export type Result<T> = {
   status: number;
-  result: T;
+  result: T & AnyJson;
 };
 
 export type ErrorResult = {
@@ -24,16 +20,22 @@ export type ErrorResult = {
   message: string;
 };
 
-export function scrubAccessTokens(auths: Authorization[]): Authorization[] {
-  auths.forEach((auth) => {
+export function scrubSecrets(auths: AuthFields | AuthFields[]): AuthFields | AuthFields[] {
+  const authsToScrub = Array.isArray(auths) ? auths : [auths];
+  authsToScrub.forEach((auth) => {
     delete auth.accessToken;
+    delete auth.clientSecret;
+    delete auth.clientId;
+    delete auth.refreshToken;
   });
   return auths;
 }
 
-export function expectAccessTokenToExist(auth: Authorization): void {
-  expect(auth.accessToken).to.exist;
-  expect(auth.accessToken).to.be.a('string');
+export function expectPropsToExist(auth: AuthFields, ...props: Array<keyof AuthFields>): void {
+  props.forEach((prop) => {
+    expect(auth[prop]).to.exist;
+    expect(auth[prop]).to.be.a('string');
+  });
 }
 
 export function parseJson<T = unknown>(jsonString: string): Result<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,7 +599,7 @@
   integrity sha512-LBcQ8rIkf6fKnN96XkfRZPbQ3yyioihJppUyZ8O+/JQjlGu6Me18YHR84ic92p+LqhtQqyth84xFvcCHmJCZxg==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^1.4.3"
+    "@salesforce/kit" "^1.3.3"
     "@salesforce/schemas" "^1.0.1"
     "@salesforce/ts-types" "^1.0.0"
     "@types/graceful-fs" "^4.1.3"
@@ -691,10 +691,10 @@
     "@salesforce/core" "^2.15.2"
     tslib "^2"
 
-"@salesforce/prettier-config@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.1.tgz#4ef70bca610ea981181fb030b25a27797b15cdff"
-  integrity sha512-o43j1I6JliElZXmTL5q1ni2frSkO5o/kCjIp7nI56cWBHWeZaM81vXOmap8TESDzIrEok6tF5jLKyEv4+SOleQ==
+"@salesforce/prettier-config@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/@salesforce/prettier-config/-/prettier-config-0.0.2.tgz#ded39bf7cb75238edc9db6dd093649111350f8bc"
+  integrity sha512-KExM355BLbxCW6siGBV7oUOotXvvVp0tAWERgzUkM2FcMb9fWrjwXDrIHc8V0UdDlA3UXtFltDWgN+Yqi+BA/g==
 
 "@salesforce/schemas@^1.0.1":
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@
     typescript "^4.1.3"
     xunit-file "^1.0.0"
 
-"@salesforce/kit@^1.2.2", "@salesforce/kit@^1.3.3", "@salesforce/kit@^1.3.4", "@salesforce/kit@^1.4.3":
+"@salesforce/kit@^1.2.2", "@salesforce/kit@^1.3.3", "@salesforce/kit@^1.3.4":
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.4.5.tgz#f892e16079e926b16f85977e3e48c86d950c8cb3"
   integrity sha512-EPR9BkbdLPr//CB9IXVPUyM0ANEvadlH7yfI1p1xA9lxzSakJk7w2CEds+8VDaJ9nlY60jjSWR8TpJWuPqU6dA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,7 +537,7 @@
     shelljs "^0.8.4"
     sinon "^9.0.2"
 
-"@salesforce/command@^3.0.0", "@salesforce/command@^3.0.3":
+"@salesforce/command@^3.0.0", "@salesforce/command@^3.0.3", "@salesforce/command@^3.0.5":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@salesforce/command/-/command-3.1.0.tgz#98874539aeda69aeb20765dcf7ed02a2945cec45"
   integrity sha512-Ggz+P35uJVd2w+R66TGz1Rs4jr6KKmyC3bkpgbJTm+yjaOjy2l/if2hus6fhZ680LUxCucDVXbyEjdzu3B+ioA==
@@ -553,10 +553,50 @@
     chalk "^2.4.2"
     cli-ux "^4.9.3"
 
-"@salesforce/core@^2.15.4", "@salesforce/core@^2.16.3", "@salesforce/core@^2.2.0":
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.20.3.tgz#fe39bdabd6053f430114dbf9c5d23d0405e9e6ad"
-  integrity sha512-gX0BJMMppc4j6OiSPSjFRIyL8T6faYtJUVGV0qhx/R3JADiazyRfBgUqvpMmRI/4bxEaV6nXAIU5Rr+EoL0ZqQ==
+"@salesforce/core@^2.15.2":
+  version "2.20.1"
+  resolved "https://registry.npmjs.org/@salesforce/core/-/core-2.20.1.tgz#624dd81dc016c616e65cb6ba9b31a02852dd5d33"
+  integrity sha512-TTvdbKAZpVNgi04gijb0ePdtX37qPA+JYQzgETh/dub6wKGIMMmnouON/rr4TDta9qVvr6kUCfaYPnv8PXiNMA==
+  dependencies:
+    "@salesforce/bunyan" "^2.0.0"
+    "@salesforce/kit" "^1.3.3"
+    "@salesforce/schemas" "^1.0.1"
+    "@salesforce/ts-types" "^1.0.0"
+    "@types/graceful-fs" "^4.1.3"
+    "@types/jsforce" "1.9.23"
+    "@types/mkdirp" "1.0.0"
+    debug "^3.1.0"
+    graceful-fs "^4.2.4"
+    jsen "0.6.6"
+    jsforce "^1.10.0"
+    jsonwebtoken "8.5.0"
+    mkdirp "1.0.4"
+    sfdx-faye "^1.0.9"
+
+"@salesforce/core@^2.15.4", "@salesforce/core@^2.2.0":
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.18.1.tgz#f6978b11ed8dd4bfd6d067d5a06acf36703fcb32"
+  integrity sha512-g41FkWtaNHcZAf5cTxrPnj5FoWDlViLpDZqUoXVcwhtN2eI1OfjXogANR8SUS1yOWiK7pSye9BOiJ3qSVmwvPg==
+  dependencies:
+    "@salesforce/bunyan" "^2.0.0"
+    "@salesforce/kit" "^1.3.3"
+    "@salesforce/schemas" "^1.0.1"
+    "@salesforce/ts-types" "^1.0.0"
+    "@types/graceful-fs" "^4.1.3"
+    "@types/jsforce" "1.9.23"
+    "@types/mkdirp" "1.0.0"
+    debug "^3.1.0"
+    graceful-fs "^4.2.4"
+    jsen "0.6.6"
+    jsforce "^1.10.0"
+    jsonwebtoken "8.5.0"
+    mkdirp "1.0.4"
+    sfdx-faye "^1.0.9"
+
+"@salesforce/core@^2.16.3":
+  version "2.18.0"
+  resolved "https://registry.npmjs.org/@salesforce/core/-/core-2.18.0.tgz#0a514682c5720c9bae4cc05a6a62edb78bdb9ded"
+  integrity sha512-LBcQ8rIkf6fKnN96XkfRZPbQ3yyioihJppUyZ8O+/JQjlGu6Me18YHR84ic92p+LqhtQqyth84xFvcCHmJCZxg==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.4.3"
@@ -641,10 +681,20 @@
     handlebars "^4.7.3"
     tslib "^1"
 
-"@salesforce/prettier-config@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.2.tgz#ded39bf7cb75238edc9db6dd093649111350f8bc"
-  integrity sha512-KExM355BLbxCW6siGBV7oUOotXvvVp0tAWERgzUkM2FcMb9fWrjwXDrIHc8V0UdDlA3UXtFltDWgN+Yqi+BA/g==
+"@salesforce/plugin-config@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/@salesforce/plugin-config/-/plugin-config-1.2.5.tgz#122c689f4b5468de99acfff1330851a6cc2a9a67"
+  integrity sha512-dDaBF6CD3S5oXk5I8W2vvpkfnisHV4zqcDV98nOXjyNkdXKaLEeQ8K1dFkjdtYag7IjlpGbh1w/nxT0jiHSASQ==
+  dependencies:
+    "@oclif/config" "^1.17.0"
+    "@salesforce/command" "^3.0.5"
+    "@salesforce/core" "^2.15.2"
+    tslib "^2"
+
+"@salesforce/prettier-config@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.1.tgz#4ef70bca610ea981181fb030b25a27797b15cdff"
+  integrity sha512-o43j1I6JliElZXmTL5q1ni2frSkO5o/kCjIp7nI56cWBHWeZaM81vXOmap8TESDzIrEok6tF5jLKyEv4+SOleQ==
 
 "@salesforce/schemas@^1.0.1":
   version "1.0.3"


### PR DESCRIPTION
### What does this PR do?
- Adds NUTs for `auth:list`, `auth:logout`, `auth:jwt:grant`, and `auth:sfdxurl:store`

This PR does NOT add any tests for `auth:web:login` or `auth:device:login` since we do not want to mock interactions with a web browser

### What issues does this PR fix or reference?
@W-8856588@

Depends on https://github.com/salesforcecli/cli-plugins-testkit/pull/32