### PR TITLE
fix(sfdxauthurl): error handling regression

### DIFF
--- a/src/commands/auth/sfdxurl/store.ts
+++ b/src/commands/auth/sfdxurl/store.ts
@@ -63,16 +63,13 @@ export default class Store extends SfdxCommand {
       ? await this.getUrlFromJson(authFile)
       : await fs.readFile(authFile, 'utf8');
 
-    let oauth2Options: AuthFields;
-    try {
-      oauth2Options = AuthInfo.parseSfdxAuthUrl(sfdxAuthUrl);
-    } catch (e) {
-      this.ux.error(
+    if (!sfdxAuthUrl) {
+      throw new Error(
         `Error getting the auth URL from file ${authFile}. Please ensure it meets the description shown in the documentation for this command.`
       );
-      this.ux.error(this.statics.description);
-      return;
     }
+
+    const oauth2Options = AuthInfo.parseSfdxAuthUrl(sfdxAuthUrl);
 
     const authInfo = await AuthInfo.create({ oauth2Options });
     await authInfo.save();


### PR DESCRIPTION
### What does this PR do?
Fixes a regression with error messages

You should now see this when encountering errors parsing or finding an sfdxAuthUrl in a json or txt file.
![image](https://user-images.githubusercontent.com/1084688/111549932-7b8ff780-8753-11eb-8523-3de7a718ad0c.png)


### What issues does this PR fix or reference?
@W-9020997@