### PR TITLE
Output auth url instead of opening it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ sfdx plugins
 # Commands
 
 <!-- commands -->
-* [`sfdx auth:device:login [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authdevicelogin--i-string--r-url--d--s--a-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
-* [`sfdx auth:jwt:grant -u <string> -f <filepath> -i <string> [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authjwtgrant--u-string--f-filepath--i-string--r-url--d--s--a-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
-* [`sfdx auth:list [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authlist---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
-* [`sfdx auth:logout [-a] [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authlogout--a--p--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
-* [`sfdx auth:sfdxurl:store -f <filepath> [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authsfdxurlstore--f-filepath--d--s--a-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
-* [`sfdx auth:web:login [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authweblogin--i-string--r-url--d--s--a-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+
+- [`sfdx auth:device:login [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authdevicelogin--i-string--r-url--d--s--a-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+- [`sfdx auth:jwt:grant -u <string> -f <filepath> -i <string> [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authjwtgrant--u-string--f-filepath--i-string--r-url--d--s--a-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+- [`sfdx auth:list [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authlist---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+- [`sfdx auth:logout [-a] [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authlogout--a--p--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+- [`sfdx auth:sfdxurl:store -f <filepath> [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authsfdxurlstore--f-filepath--d--s--a-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+- [`sfdx auth:web:login [-o] [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-authweblogin--o--i-string--r-url--d--s--a-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 
 ## `sfdx auth:device:login [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -82,7 +83,7 @@ authorize an org using a device code
 
 ```
 USAGE
-  $ sfdx auth:device:login [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel 
+  $ sfdx auth:device:login [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -117,7 +118,7 @@ EXAMPLES
   sfdx auth:device:login -r https://test.salesforce.com
 ```
 
-_See code: [src/commands/auth/device/login.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.0/src/commands/auth/device/login.ts)_
+_See code: [src/commands/auth/device/login.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.1/src/commands/auth/device/login.ts)_
 
 ## `sfdx auth:jwt:grant -u <string> -f <filepath> -i <string> [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -125,7 +126,7 @@ authorize an org using the JWT flow
 
 ```
 USAGE
-  $ sfdx auth:jwt:grant -u <string> -f <filepath> -i <string> [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel 
+  $ sfdx auth:jwt:grant -u <string> -f <filepath> -i <string> [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -158,8 +159,8 @@ OPTIONS
 
 DESCRIPTION
   Use a certificate associated with your private key that has been uploaded to a personal connected app.
-  If you specify an --instanceurl value, this value overrides the sfdcLoginUrl value in your sfdx-project.json file. To 
-  specify a My Domain URL, use the format MyDomainName.my.salesforce.com (not MyDomainName.lightning.force.com). To 
+  If you specify an --instanceurl value, this value overrides the sfdcLoginUrl value in your sfdx-project.json file. To
+  specify a My Domain URL, use the format MyDomainName.my.salesforce.com (not MyDomainName.lightning.force.com). To
   specify a sandbox, set --instanceurl to https://test.salesforce.com.
 
 ALIASES
@@ -171,7 +172,7 @@ EXAMPLES
   sfdx auth:jwt:grant -u me@acme.org -f <path to jwt key file> -i <OAuth client id> -r https://acme.my.salesforce.com
 ```
 
-_See code: [src/commands/auth/jwt/grant.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.0/src/commands/auth/jwt/grant.ts)_
+_See code: [src/commands/auth/jwt/grant.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.1/src/commands/auth/jwt/grant.ts)_
 
 ## `sfdx auth:list [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -191,7 +192,7 @@ ALIASES
   $ sfdx force:auth:list
 ```
 
-_See code: [src/commands/auth/list.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.0/src/commands/auth/list.ts)_
+_See code: [src/commands/auth/list.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.1/src/commands/auth/list.ts)_
 
 ## `sfdx auth:logout [-a] [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -199,7 +200,7 @@ log out from authorized orgs
 
 ```
 USAGE
-  $ sfdx auth:logout [-a] [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel 
+  $ sfdx auth:logout [-a] [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -229,7 +230,7 @@ EXAMPLES
   sfdx auth:logout -p
 ```
 
-_See code: [src/commands/auth/logout.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.0/src/commands/auth/logout.ts)_
+_See code: [src/commands/auth/logout.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.1/src/commands/auth/logout.ts)_
 
 ## `sfdx auth:sfdxurl:store -f <filepath> [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -237,7 +238,7 @@ Authorize an org using an SFDX auth URL
 
 ```
 USAGE
-  $ sfdx auth:sfdxurl:store -f <filepath> [-d] [-s] [-a <string>] [--json] [--loglevel 
+  $ sfdx auth:sfdxurl:store -f <filepath> [-d] [-s] [-a <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -261,9 +262,9 @@ OPTIONS
                                                                                     this command invocation
 
 DESCRIPTION
-  Authorize a Salesforce org using an SFDX auth URL stored within a file. The URL must have the format 
+  Authorize a Salesforce org using an SFDX auth URL stored within a file. The URL must have the format
   "force://<refreshToken>@<instanceUrl>" or "force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>".
-  You have three options when creating the auth file. The easiest option is to redirect the output of the `sfdx 
+  You have three options when creating the auth file. The easiest option is to redirect the output of the `sfdx
   force:org:display --verbose --json` command into a file.
   For example, using an org you have already authorized:
 
@@ -282,15 +283,15 @@ EXAMPLES
   sfdx auth:sfdxurl:store -f <path to sfdxAuthUrl file> -s -a MyDefaultOrg
 ```
 
-_See code: [src/commands/auth/sfdxurl/store.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.0/src/commands/auth/sfdxurl/store.ts)_
+_See code: [src/commands/auth/sfdxurl/store.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.1/src/commands/auth/sfdxurl/store.ts)_
 
-## `sfdx auth:web:login [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
+## `sfdx auth:web:login [-o] [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
 authorize an org using the web login flow
 
 ```
 USAGE
-  $ sfdx auth:web:login [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel 
+  $ sfdx auth:web:login [-o] [-i <string>] [-r <url>] [-d] [-s] [-a <string>] [--json] [--loglevel
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -303,6 +304,8 @@ OPTIONS
 
   -i, --clientid=clientid                                                           OAuth client ID (sometimes called
                                                                                     the consumer key)
+
+  -o, --outputurl                                                                   Output the URL instead of opening it
 
   -r, --instanceurl=instanceurl                                                     the login URL of the instance the
                                                                                     org lives on
@@ -317,8 +320,8 @@ OPTIONS
                                                                                     this command invocation
 
 DESCRIPTION
-  If you specify an --instanceurl value, this value overrides the sfdcLoginUrl value in your sfdx-project.json file. To 
-  specify a My Domain URL, use the format MyDomainName.my.salesforce.com (not MyDomainName.lightning.force.com). To log 
+  If you specify an --instanceurl value, this value overrides the sfdcLoginUrl value in your sfdx-project.json file. To
+  specify a My Domain URL, use the format MyDomainName.my.salesforce.com (not MyDomainName.lightning.force.com). To log
   in to a sandbox, set --instanceurl to https://test.salesforce.com.
 
 ALIASES
@@ -330,5 +333,6 @@ EXAMPLES
   sfdx auth:web:login -r https://test.salesforce.com
 ```
 
-_See code: [src/commands/auth/web/login.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.0/src/commands/auth/web/login.ts)_
+_See code: [src/commands/auth/web/login.ts](https://github.com/salesforcecli/plugin-auth/blob/v1.5.1/src/commands/auth/web/login.ts)_
+
 <!-- commandsstop -->

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -64,7 +64,8 @@
       "noprompt",
       "setalias",
       "setdefaultdevhubusername",
-      "setdefaultusername"
+      "setdefaultusername",
+      "outputurl"
     ]
   }
 ]

--- a/messages/messages.json
+++ b/messages/messages.json
@@ -28,5 +28,6 @@
   "warnAuth": "Logging in to a business or production org is not recommended on a demo or shared machine. Please run \"sfdx auth:logout --targetusername <your username> --noprompt\" when finished using this org, which is similar to logging out of the org in the browser.\n\nDo you want to authorize this org for use with the Salesforce CLI (y/n)?",
   "noPromptAuth": "do not prompt for auth confirmation in demo mode",
   "disableMasking": "disable masking of user input (for use with problematic terminals)",
-  "clientSecretStdin": "OAuth client secret of personal connected app?"
+  "clientSecretStdin": "OAuth client secret of personal connected app?",
+  "outputUrl": "Output the URL instead of opening it"
 }

--- a/src/commands/auth/web/login.ts
+++ b/src/commands/auth/web/login.ts
@@ -25,7 +25,7 @@ export default class Login extends SfdxCommand {
   public static aliases = ['force:auth:web:login'];
 
   public static readonly flagsConfig: FlagsConfig = {
-    output: flags.boolean({
+    outputurl: flags.boolean({
       char: 'o',
       default: false,
       description: commonMessages.getMessage('outputUrl'),

--- a/src/commands/auth/web/login.ts
+++ b/src/commands/auth/web/login.ts
@@ -25,6 +25,11 @@ export default class Login extends SfdxCommand {
   public static aliases = ['force:auth:web:login'];
 
   public static readonly flagsConfig: FlagsConfig = {
+    output: flags.boolean({
+      char: 'o',
+      default: false,
+      description: commonMessages.getMessage('outputUrl'),
+    }),
     clientid: flags.string({
       char: 'i',
       description: commonMessages.getMessage('clientId'),
@@ -93,7 +98,8 @@ export default class Login extends SfdxCommand {
   private async executeLoginFlow(oauthConfig: OAuth2Options): Promise<AuthInfo> {
     const oauthServer = await WebOAuthServer.create({ oauthConfig });
     await oauthServer.start();
-    await open(oauthServer.getAuthorizationUrl(), { wait: false });
+    if (this.flags.output) this.ux.log(oauthServer.getAuthorizationUrl());
+    else await open(oauthServer.getAuthorizationUrl(), { wait: false });
     return oauthServer.authorizeAndSave();
   }
 

--- a/src/commands/auth/web/login.ts
+++ b/src/commands/auth/web/login.ts
@@ -98,7 +98,7 @@ export default class Login extends SfdxCommand {
   private async executeLoginFlow(oauthConfig: OAuth2Options): Promise<AuthInfo> {
     const oauthServer = await WebOAuthServer.create({ oauthConfig });
     await oauthServer.start();
-    if (this.flags.output) this.ux.log(oauthServer.getAuthorizationUrl());
+    if (this.flags.outputurl) this.ux.log(oauthServer.getAuthorizationUrl());
     else await open(oauthServer.getAuthorizationUrl(), { wait: false });
     return oauthServer.authorizeAndSave();
   }


### PR DESCRIPTION
### What does this PR do?
Simply output the url instead of opening it.


### What issues does this PR fix or reference?
I would like to fully automate my devhub creation.  However currently `auth:web:login` requires user intervention to continue.
With this change, I can write a puppeteer process to read the outputed url, auth then continue.

This is how i'm using it in my POC and it works with the new `-o` switch.
```javascript
await new Promise(resolve => {
    const res = shellDetached(`sfdx auth:web:login -o -d -a "${hubOrgAlias}" -r "${instanceUrl}"` + (this.devHubConfig.sfdcLoginUrl ? ` --instanceurl "${this.devHubConfig.sfdcLoginUrl}"` : ''));
    res.stdout.on("data", output => this.autoAuth(output.toString()));
    res.on("exit", code => resolve(code));
});
private async autoAuth(url: string) {
    this.ux.setSpinnerStatus('Got URL');
    const browser = await puppeteer.launch({
        headless: true,
        args: ['--no-sandbox', '--disable-web-security', '--disable-features=IsolateOrigins,site-per-process'],
        ignoreHTTPSErrors: true
    });
    const page = await browser.newPage();
    this.ux.setSpinnerStatus(`opening ${url}`);
    await page.goto(url);
    this.ux.setSpinnerStatus('Waiting for login page to load');
    await page.waitForSelector('#username', { timeout: 20000, visible: true });
    try {
        await page.focus('#username');
        await page.keyboard.type('ceo@mydevhub.com');
        await page.focus('#password');
        await page.keyboard.type('123456');
        await page.click('#Login');
        this.ux.setSpinnerStatus('Waiting for Allow Access page to load');
        await page.waitForSelector('#oaapprove', { timeout: 20000, visible: true });
        await page.click('#oaapprove');
        this.ux.setSpinnerStatus('Waiting for Next Page to load');
        await page.waitForSelector('#bodyCell', { timeout: 20000, visible: true });
    } finally {
        await browser.close();
        this.ux.setSpinnerStatus('Org Access Allowed');
    }
}
```