### PR TITLE
fix: test for lightning instance url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,13 @@ workflows:
       - release-management/test-package:
           matrix:
             parameters:
-              os: ["linux","windows"]
-              node_version: ["latest","lts","maintenance"]
+              os:
+                - linux
+                - windows
+              node_version:
+                - latest
+                - lts
+                - maintenance
             exclude:
               - os: windows
                 node_version: lts

--- a/messages/messages.json
+++ b/messages/messages.json
@@ -28,5 +28,6 @@
   "warnAuth": "Logging in to a business or production org is not recommended on a demo or shared machine. Please run \"sfdx auth:logout --targetusername <your username> --noprompt\" when finished using this org, which is similar to logging out of the org in the browser.\n\nDo you want to authorize this org for use with the Salesforce CLI (y/n)?",
   "noPromptAuth": "do not prompt for auth confirmation in demo mode",
   "disableMasking": "disable masking of user input (for use with problematic terminals)",
-  "clientSecretStdin": "OAuth client secret of personal connected app?"
+  "clientSecretStdin": "OAuth client secret of personal connected app?",
+  "invalidInstanceUrl": "Invalid instance URL. Specify a Salesforce instance URL using the format <domainname>.salesforce.com"
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -29,10 +29,14 @@ export class Common {
     }
   }
   public static async resolveLoginUrl(instanceUrl: Optional<string>): Promise<Optional<string>> {
+    const logger = await Logger.child('Common', { tag: 'resolveLoginUrl' });
     if (instanceUrl) {
+      if (instanceUrl.includes('lightning.force.com')) {
+        logger.warn(messages.getMessage('invalidInstanceUrl'));
+        throw new SfdxError(messages.getMessage('invalidInstanceUrl'), 'URL_WARNING');
+      }
       return instanceUrl;
     }
-    const logger = await Logger.child('Common', { tag: 'resolveLoginUrl' });
     let loginUrl: string;
     try {
       const project = await SfdxProject.resolve();

--- a/src/common.ts
+++ b/src/common.ts
@@ -5,8 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, Logger, SfdcUrl, SfdxProject } from '@salesforce/core';
+import { AuthInfo, Logger, SfdcUrl, SfdxProject, Messages, SfdxError } from '@salesforce/core';
 import { getString, isObject, Optional } from '@salesforce/ts-types';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-auth', 'messages');
 
 interface Flags {
   setalias?: string;
@@ -39,6 +42,10 @@ export class Common {
       const message: string = (isObject(err) ? Reflect.get(err, 'message') ?? err : err) as string;
       logger.debug(`error occurred while trying to determine loginUrl: ${message}`);
       loginUrl = SfdcUrl.PRODUCTION;
+    }
+    if (loginUrl.includes('lightning.force.com')) {
+      logger.warn(messages.getMessage('invalidInstanceUrl'));
+      throw new SfdxError(messages.getMessage('invalidInstanceUrl'), 'URL_WARNING');
     }
     logger.debug(`loginUrl: ${loginUrl}`);
     return loginUrl;

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -69,6 +69,7 @@ describe('common unit tests', () => {
       });
       try {
         await Common.resolveLoginUrl(undefined);
+        expect(1).to.equal('This test is failing because it is expecting an error that is never thrown');
       } catch (error) {
         const err = error as SfdxError;
         expect(err.name).to.equal('URL_WARNING');

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SfdcUrl, SfdxProject } from '@salesforce/core';
+import { SfdcUrl, SfdxProject, SfdxError } from '@salesforce/core';
 import sinon = require('sinon');
 import { expect } from '@salesforce/command/lib/test';
 import { restoreContext, testSetup } from '@salesforce/core/lib/testSetup';
@@ -55,6 +55,24 @@ describe('common unit tests', () => {
       });
       const loginUrl = await Common.resolveLoginUrl(undefined);
       expect(loginUrl).to.equal(SfdcUrl.PRODUCTION);
+    });
+    it('should throw on lightning login URL', async () => {
+      sandbox.stub(SfdxProject.prototype, 'resolveProjectConfig').resolves({
+        packageDirectories: [
+          {
+            path: 'force-app',
+            default: true,
+          },
+        ],
+        sfdcLoginUrl: 'https://shanedevhub.lightning.force.com',
+        sourceApiVersion: '50.0',
+      });
+      try {
+        await Common.resolveLoginUrl(undefined);
+      } catch (error) {
+        const err = error as SfdxError;
+        expect(err.name).to.equal('URL_WARNING');
+      }
     });
   });
   describe('custom login url', () => {

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -56,7 +56,7 @@ describe('common unit tests', () => {
       const loginUrl = await Common.resolveLoginUrl(undefined);
       expect(loginUrl).to.equal(SfdcUrl.PRODUCTION);
     });
-    it('should throw on lightning login URL', async () => {
+    it('should throw on lightning login URL in sfdcLoginUrl propery', async () => {
       sandbox.stub(SfdxProject.prototype, 'resolveProjectConfig').resolves({
         packageDirectories: [
           {
@@ -69,7 +69,16 @@ describe('common unit tests', () => {
       });
       try {
         await Common.resolveLoginUrl(undefined);
-        expect(1).to.equal('This test is failing because it is expecting an error that is never thrown');
+        sinon.assert.fail('This test is failing because it is expecting an error that is never thrown');
+      } catch (error) {
+        const err = error as SfdxError;
+        expect(err.name).to.equal('URL_WARNING');
+      }
+    });
+    it('should throw on lightning login URL passed in to resolveLoginUrl()', async () => {
+      try {
+        await Common.resolveLoginUrl('https://shanedevhub.lightning.force.com');
+        sinon.assert.fail('This test is failing because it is expecting an error that is never thrown');
       } catch (error) {
         const err = error as SfdxError;
         expect(err.name).to.equal('URL_WARNING');


### PR DESCRIPTION
### What does this PR do?
Prevent CLI users from using lightning domain URLs in sfdx

### What issues does this PR fix or reference?
@W-5494117@
