### PR TITLE
fix: add missing long command description

### DIFF
--- a/messages/device.login.json
+++ b/messages/device.login.json
@@ -1,5 +1,5 @@
 {
-  "description": "authorize an org using a device code",
+  "description": "authorize an org using a device code\nYou must open a browser, navigate to the verification URL, and enter the code. Log in, if not already logged in, and you’ll be prompted to allow the device to connect to the org.",
   "examples": [
     "sfdx auth:device:login -d -a TestOrg1",
     "sfdx auth:device:login -i <OAuth client id>",


### PR DESCRIPTION
### What does this PR do?

Adds back missing command description that was lost when the auth commands were broken out into their own plugin.  

NOTE: I used this old version of the CLI Reference when searching for missing content: https://developer.salesforce.com/docs/atlas.en-us.224.0.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_force_auth.htm#cli_reference_device_login

### What issues does this PR fix or reference?
@W-10049649@