### PR TITLE
fix: set isDevHub when --setdefaultdevhubusername is passed

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -23,6 +23,9 @@ export class Common {
     if (flags.setalias) await authInfo.setAlias(flags.setalias);
 
     if (flags.setdefaultdevhubusername || flags.setdefaultusername) {
+      if (flags.setdefaultdevhubusername) {
+        await authInfo.save({ isDevHub: true });
+      }
       await authInfo.setAsDefault({
         defaultUsername: flags.setdefaultusername,
         defaultDevhubUsername: flags.setdefaultdevhubusername,


### PR DESCRIPTION
### What does this PR do?
sets `isDevHub` in the auth file 

### What issues does this PR fix or reference?
@W-10811265@
https://github.com/forcedotcom/cli/issues/1423