### PR TITLE
chore: use node LTS for t+r

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ parameters:
     default: ''
     type: string
   repo_tag:
-    description: 'The tag of the module repo to checkout, '''' defaults to branch/PR'
+    description: "The tag of the module repo to checkout, '' defaults to branch/PR"
     default: ''
     type: string
   npm_module_name:
@@ -75,6 +75,7 @@ workflows:
       - release-management/release-package:
           sign: true
           github-release: true
+          node_version: lts
           requires:
             - release-management/test-package
           filters:


### PR DESCRIPTION
### What does this PR do?
set node to lts for `test-and-release` CI Job
### What issues does this PR fix or reference?
[skip-validate-pr]