### PR TITLE
fix: error when using a browser that isn't installed

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Node",
+      "port": 9229,
+      "restart": true,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}

--- a/src/commands/auth/web/login.ts
+++ b/src/commands/auth/web/login.ts
@@ -108,9 +108,14 @@ export default class Login extends SfdxCommand {
     const oauthServer = await WebOAuthServer.create({ oauthConfig });
     await oauthServer.start();
     const openOptions = this.flags.browser
-      ? { app: { name: open.apps[this.flags.browser as string] as open.AppName }, wait: false }
-      : { wait: false };
-    await open(oauthServer.getAuthorizationUrl(), openOptions);
+            ? { app: { name: open.apps[this.flags.browser as string] as open.AppName }, wait: true, allowNonzeroExitCode: true }
+            : { wait: false };
+        try {
+            await open(oauthServer.getAuthorizationUrl(), openOptions);
+        }
+        catch (err) {
+            throw new SfError(`Failed to open browser: ${this.flags.browser as string}`, 'Browser open error', [`Check to see that ${this.flags.browser as string} is installed`], 1);
+        }
     return oauthServer.authorizeAndSave();
   }
 }


### PR DESCRIPTION
### What does this PR do?

It causes `auth:web:login --browser <name>` to error when trying to use a browser that doesn't exist and prints that error to the terminal.

### What issues does this PR fix or reference?
fixes https://github.com/forcedotcom/cli/issues/1830