### PR TITLE
fix(list): empty list when no authed orgs are found

### DIFF
--- a/src/commands/auth/list.ts
+++ b/src/commands/auth/list.ts
@@ -20,6 +20,10 @@ export default class List extends SfdxCommand {
   public async run(): Promise<OrgAuthorization[]> {
     try {
       const auths = await AuthInfo.listAllAuthorizations();
+      if (auths.length === 0) {
+        this.ux.log(messages.getMessage('noResultsFound'));
+        return [];
+      }
       auths.map((auth: OrgAuthorization & { alias: string }) => {
         // core3 moved to aliases as a string[], revert to alias as a string
         auth.alias = auth.aliases.join(',');


### PR DESCRIPTION
### What does this PR do?
Fix the list printing empty table when no auth'd orgs are found

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1796

As suggested by @cristiand391, I've simply added a check for the length of the array returned by AuthInfo.listAllAuthorizations to avoid relying on the error to be throw thrown.

