### PR TITLE
Sm/sf-aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "sinon": "10.0.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.9.4",
-    "wireit": "^0.9.3"
+    "wireit": "^0.9.5"
   },
   "engines": {
     "node": ">=14.0.0"
@@ -131,10 +131,6 @@
     "prepare": "sf-install",
     "reformat": "prettier --config .prettierrc --write './*.{js,json,md}' './**/*.{ts,json,md}'",
     "test": "wireit",
-    "test:command-reference": "wireit",
-    "test:compile": "wireit",
-    "test:deprecation-policy": "wireit",
-    "test:json-schema": "wireit",
     "test:nuts": "nyc mocha \"**/*.nut.ts\" --slow 4500 --timeout 600000 --parallel --jobs 20",
     "test:only": "wireit",
     "version": "oclif readme"
@@ -163,7 +159,15 @@
       "clean": "if-file-deleted"
     },
     "format": {
-      "command": "prettier --write \"+(src|test|schemas)/**/*.+(ts|js|json)|command-snapshot.json\""
+      "command": "prettier --write \"+(src|test|schemas)/**/*.+(ts|js|json)|command-snapshot.json\"",
+      "files": [
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "schemas/**/*.json",
+        "command-snapshot.json",
+        ".prettier*"
+      ],
+      "output": []
     },
     "lint": {
       "command": "eslint src test --color --cache --cache-location .eslintcache",
@@ -171,8 +175,7 @@
         "src/**/*.ts",
         "test/**/*.ts",
         "messages/**",
-        ".eslintignore",
-        ".eslintrc.js"
+        ".eslint*"
       ],
       "output": []
     },
@@ -201,7 +204,10 @@
         "test/**/*.ts",
         "src/**/*.ts",
         "tsconfig.json",
-        "test/tsconfig.json"
+        ".mocha*",
+        "test/tsconfig.json",
+        "!*.nut.ts",
+        ".nycrc"
       ],
       "output": []
     },
@@ -209,7 +215,8 @@
       "command": "\"./bin/dev\" commandreference:generate --erroronwarnings",
       "files": [
         "src/**/*.ts",
-        "messages/**"
+        "messages/**",
+        "package.json"
       ],
       "output": [
         "tmp/root"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@oclif/plugin-command-snapshot": "^3.3.6",
     "@salesforce/cli-plugins-testkit": "^3.2.18",
     "@salesforce/dev-config": "^3.1.0",
-    "@salesforce/dev-scripts": "^4.0.0-beta.9",
+    "@salesforce/dev-scripts": "^4.1.0",
     "@salesforce/plugin-command-reference": "^2",
     "@salesforce/plugin-config": "^1.4.23",
     "@salesforce/prettier-config": "^0.0.2",

--- a/src/commands/org/login/jwt.ts
+++ b/src/commands/org/login/jwt.ts
@@ -49,7 +49,7 @@ export default class LoginJwt extends AuthBaseCommand<AuthFields> {
       summary: commonMessages.getMessage('flags.instance-url.summary'),
       description: commonMessages.getMessage('flags.instance-url.description'),
       deprecateAliases: true,
-      aliases: ['instanceurl', '-l'],
+      aliases: ['instanceurl', 'l'],
     }),
     'set-default-dev-hub': Flags.boolean({
       char: 'd',

--- a/src/commands/org/login/jwt.ts
+++ b/src/commands/org/login/jwt.ts
@@ -55,7 +55,7 @@ export default class LoginJwt extends AuthBaseCommand<AuthFields> {
       char: 'd',
       summary: commonMessages.getMessage('flags.set-default-dev-hub.summary'),
       deprecateAliases: true,
-      aliases: ['setdefaultdevhub', 'setdefaultdevhubusername'],
+      aliases: ['setdefaultdevhub', 'setdefaultdevhubusername', 'v'],
     }),
     'set-default': Flags.boolean({
       char: 's',

--- a/src/commands/org/login/jwt.ts
+++ b/src/commands/org/login/jwt.ts
@@ -35,7 +35,7 @@ export default class LoginJwt extends AuthBaseCommand<AuthFields> {
       summary: messages.getMessage('flags.jwt-key-file.summary'),
       required: true,
       deprecateAliases: true,
-      aliases: ['jwtkeyfile'],
+      aliases: ['jwtkeyfile', 'keyfile'],
     }),
     'client-id': Flags.string({
       char: 'i',
@@ -49,7 +49,7 @@ export default class LoginJwt extends AuthBaseCommand<AuthFields> {
       summary: commonMessages.getMessage('flags.instance-url.summary'),
       description: commonMessages.getMessage('flags.instance-url.description'),
       deprecateAliases: true,
-      aliases: ['instanceurl'],
+      aliases: ['instanceurl', '-l'],
     }),
     'set-default-dev-hub': Flags.boolean({
       char: 'd',

--- a/src/commands/org/login/web.ts
+++ b/src/commands/org/login/web.ts
@@ -51,7 +51,7 @@ export default class LoginWeb extends AuthBaseCommand<AuthFields> {
       char: 'd',
       summary: commonMessages.getMessage('flags.set-default-dev-hub.summary'),
       deprecateAliases: true,
-      aliases: ['setdefaultdevhubusername', 'setdefaultdevhub', '-v'],
+      aliases: ['setdefaultdevhubusername', 'setdefaultdevhub', 'v'],
     }),
     'set-default': Flags.boolean({
       char: 's',

--- a/src/commands/org/login/web.ts
+++ b/src/commands/org/login/web.ts
@@ -45,7 +45,7 @@ export default class LoginWeb extends AuthBaseCommand<AuthFields> {
       summary: commonMessages.getMessage('flags.instance-url.summary'),
       description: commonMessages.getMessage('flags.instance-url.description'),
       deprecateAliases: true,
-      aliases: ['instanceurl', '-l'],
+      aliases: ['instanceurl', 'l'],
     }),
     'set-default-dev-hub': Flags.boolean({
       char: 'd',

--- a/src/commands/org/login/web.ts
+++ b/src/commands/org/login/web.ts
@@ -45,13 +45,13 @@ export default class LoginWeb extends AuthBaseCommand<AuthFields> {
       summary: commonMessages.getMessage('flags.instance-url.summary'),
       description: commonMessages.getMessage('flags.instance-url.description'),
       deprecateAliases: true,
-      aliases: ['instanceurl'],
+      aliases: ['instanceurl', '-l'],
     }),
     'set-default-dev-hub': Flags.boolean({
       char: 'd',
       summary: commonMessages.getMessage('flags.set-default-dev-hub.summary'),
       deprecateAliases: true,
-      aliases: ['setdefaultdevhubusername', 'setdefaultdevhub'],
+      aliases: ['setdefaultdevhubusername', 'setdefaultdevhub', '-v'],
     }),
     'set-default': Flags.boolean({
       char: 's',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7722,7 +7722,7 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
-wireit@^0.9.3, wireit@^0.9.5:
+wireit@^0.9.5:
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/wireit/-/wireit-0.9.5.tgz#7c3622f6ff5e63b7fac05783baf82f967f52562c"
   integrity sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,10 +1111,10 @@
   resolved "https://registry.yarnpkg.com/@salesforce/dev-config/-/dev-config-3.1.0.tgz#8eb5b35860ff60d1c1dc3fd9329b01a28475d5b9"
   integrity sha512-cPph7ibj3DeSzWDFLcLtxOh5fmUlDUY2Ezq43n0V6auVP+l8orxRHjCExHS86SB3QKVgXkC8yYhryXiS8KF7Zw==
 
-"@salesforce/dev-scripts@^4.0.0-beta.9":
-  version "4.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/@salesforce/dev-scripts/-/dev-scripts-4.0.0-beta.9.tgz#da6b699e80c0ea6d484942fe51fa9d1f7317688d"
-  integrity sha512-biFkKPIFO2Bje9dWd8u6sfq5Ph1DXVnGlkmrzoe0jfTAWAzveddPUenX7V8XC4btd7YRJm02QtkAo/KAgKXmvQ==
+"@salesforce/dev-scripts@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/dev-scripts/-/dev-scripts-4.1.0.tgz#955255b7bc70f1e0c993cb0d2aa67d98efcb2632"
+  integrity sha512-plRjF4PWoYz/4n/q8ha28rS5Qmx9TJWk6hfXp2jpTqOJajdZjXL0mWjPCEWlfvFm3xvQcdH1HGGKsWcl71x6sQ==
   dependencies:
     "@commitlint/cli" "^17.1.2"
     "@commitlint/config-conventional" "^17.1.0"
@@ -1149,7 +1149,7 @@
     typedoc "0.23.16"
     typedoc-plugin-missing-exports "0.23.0"
     typescript "^4.1.3"
-    wireit "^0.9.3"
+    wireit "^0.9.5"
 
 "@salesforce/kit@^1.8.0", "@salesforce/kit@^1.8.2", "@salesforce/kit@^1.8.3", "@salesforce/kit@^1.8.5":
   version "1.9.0"
@@ -7722,7 +7722,7 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
-wireit@^0.9.3:
+wireit@^0.9.3, wireit@^0.9.5:
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/wireit/-/wireit-0.9.5.tgz#7c3622f6ff5e63b7fac05783baf82f967f52562c"
   integrity sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==


### PR DESCRIPTION
### What does this PR do?
sf's web and jwt login commands had some flag names and chars that didn't get aliased.

This fixes most of those, with the exception of -d (for setting as the default username) because sfdx was using -d as setdefaultdevhubusername.  So that'll stay broken.

### What issues does this PR fix or reference?
