### PR TITLE
fix: regex lightning is surrounded by period

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,7 @@
 {
   "require": "ts-node/register,source-map-support/register",
   "watch-extensions": "ts",
+  "watch-files": ["src", "test"],
   "recursive": true,
   "reporter": "spec",
   "timeout": 10000

--- a/src/common.ts
+++ b/src/common.ts
@@ -35,7 +35,7 @@ export class Common {
 }
 
 const throwIfLightning = (urlString?: string): void => {
-  if (urlString?.match(/lightning\..*force\.com/)) {
+  if (urlString?.match(/\.lightning\..*force\.com/)) {
     throw new SfError(messages.getMessage('lightningInstanceUrl'), 'LightningDomain', [
       messages.getMessage('flags.instance-url.description'),
     ]);

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -91,6 +91,12 @@ describe('common unit tests', () => {
       }
     });
 
+    it('should allow a domain containing lightning in its login URL', async () => {
+      await projectSetup($$, true);
+      const loginUrl = await Common.resolveLoginUrl('https://mycompany-lightning.my.salesforce.com');
+      expect(loginUrl).equals('https://mycompany-lightning.my.salesforce.com');
+    });
+
     it('should throw on internal lightning login URL passed in to resolveLoginUrl()', async () => {
       await projectSetup($$, true);
       try {


### PR DESCRIPTION
### What does this PR do?
allows foo-lightning.my.salesforce.com login urls

@W-13639832@

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2241
