### PR TITLE
feat: add --sfdx-url-stdin flag

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -82,8 +82,17 @@
   {
     "command": "org:login:sfdx-url",
     "plugin": "@salesforce/plugin-auth",
-    "flags": ["alias", "json", "loglevel", "no-prompt", "set-default", "set-default-dev-hub", "sfdx-url-file"],
     "alias": ["force:auth:sfdxurl:store", "auth:sfdxurl:store"],
+    "flags": [
+      "alias",
+      "json",
+      "loglevel",
+      "no-prompt",
+      "set-default",
+      "set-default-dev-hub",
+      "sfdx-url-file",
+      "sfdx-url-stdin"
+    ],
     "flagChars": ["a", "d", "f", "p", "s"],
     "flagAliases": [
       "noprompt",

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -22,6 +22,10 @@ You can also create a JSON file that has a top-level property named sfdxAuthUrl 
 
 Path to a file that contains the Salesforce DX authorization URL.
 
+# flags.sfdx-url-stdin.summary
+
+Read sfdx auth url from stdin
+
 # examples
 
 - Authorize an org using the SFDX authorization URL in the files/authFile.json file:
@@ -31,3 +35,7 @@ Path to a file that contains the Salesforce DX authorization URL.
 - Similar to previous example, but set the org as your default and give it an alias MyDefaultOrg:
 
   <%= config.bin %> <%= command.id %> --sfdx-url-file files/authFile.json --set-default --alias MyDefaultOrg
+
+- Authorize an org reading the SFDX authorization URL from stdin:
+
+  echo 'force://PlatformCLI::CoffeeAndBacon@su0503.my.salesforce.com' | <%= config.bin %> <%= command.id %> --sfdx-url-stdin --set-default --alias MyDefaultOrg

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export function read(): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const stdin = process.openStdin();
+    stdin.setEncoding('utf-8');
+
+    let data = '';
+    stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+
+    stdin.on('end', () => {
+      resolve(data);
+    });
+
+    if (stdin.isTTY) {
+      resolve('');
+    }
+  });
+}

--- a/test/commands/org/login/login.sfdx-url.nut.ts
+++ b/test/commands/org/login/login.sfdx-url.nut.ts
@@ -56,4 +56,12 @@ describe('org:login:sfdx-url NUTs', () => {
     const output = getString(result, 'shellOutput.stdout');
     expect(output).to.include(`Successfully authorized ${username} with org ID`);
   });
+
+  it('should authorize an org using sfdx-url (human readable)', () => {
+    env.setString('TESTKIT_EXECUTABLE_PATH', `echo '${authUrl}' | ${env.getString('TESTKIT_EXECUTABLE_PATH')}`);
+    const command = 'org:login:sfdx-url -d --sfdx-url-stdin';
+    const result = execCmd(command, { ensureExitCode: 0 });
+    const output = getString(result, 'shellOutput.stdout');
+    expect(output).to.include(`Successfully authorized ${username} with org ID`);
+  });
 });

--- a/test/commands/org/login/login.sfdx-url.test.ts
+++ b/test/commands/org/login/login.sfdx-url.test.ts
@@ -13,6 +13,7 @@ import { Config } from '@oclif/core';
 import { StubbedType, stubInterface } from '@salesforce/ts-sinon';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 import LoginSfdxUrl from '../../../../src/commands/org/login/sfdx-url';
+import * as stdin from '../../../../src/stdin';
 
 interface Options {
   authInfoCreateFails?: boolean;
@@ -91,7 +92,7 @@ describe('org:login:sfdx-url', () => {
       const response = await store.run();
       expect.fail(`Should have thrown an error. Response: ${JSON.stringify(response)}`);
     } catch (e) {
-      expect((e as Error).message).to.includes('Error getting the auth URL from file');
+      expect((e as Error).message).to.includes('Error retrieving the auth URL');
     }
   });
 
@@ -212,5 +213,24 @@ describe('org:login:sfdx-url', () => {
     const store = new LoginSfdxUrl(['-p', '-f', keyPathTxt, '--json'], {} as Config);
     await store.run();
     expect(authInfoStub.save.callCount).to.equal(1);
+  });
+
+  it('should return auth fields when reading auth url from stdin', async () => {
+    await prepareStubs({ fileDoesNotExist: true });
+    $$.SANDBOX.stub(stdin, 'read').resolves('force://PlatformCLI::CoffeeAndBacon@su0503.my.salesforce.com');
+    const store = new LoginSfdxUrl(['--sfdx-url-stdin', '--json'], {} as Config);
+    const response = await store.run();
+    expect(response.username).to.equal(testData.username);
+  });
+
+  it('should throw error when passing both sfdx-url-stdin and sfdx-url-file', async () => {
+    const store = new LoginSfdxUrl(['--sfdx-url-stdin', '--sfdx-url-file', 'path/to/key.txt', '--json'], {} as Config);
+
+    try {
+      const response = await store.run();
+      expect.fail(`Should have thrown an error. Response: ${JSON.stringify(response)}`);
+    } catch (e) {
+      expect((e as Error).message).to.includes('--sfdx-url-file cannot also be provided when using --sfdx-url-stdin');
+    }
   });
 });


### PR DESCRIPTION
### What does this PR do?
With these changes developers can pipe the sfdx auth url from stdin as follows:

`echo 'force://PlatformCLI::CoffeeAndBacon@su0503.my.salesforce.com' | sfdx org:login:sfdx-url --sfdx-url-stdin`

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2120