### PR TITLE
feat: add --sfdx-url-stdin flag

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -82,8 +82,17 @@
   {
     "command": "org:login:sfdx-url",
     "plugin": "@salesforce/plugin-auth",
-    "flags": ["alias", "json", "loglevel", "no-prompt", "set-default", "set-default-dev-hub", "sfdx-url-file"],
     "alias": ["force:auth:sfdxurl:store", "auth:sfdxurl:store"],
+    "flags": [
+      "alias",
+      "json",
+      "loglevel",
+      "no-prompt",
+      "set-default",
+      "set-default-dev-hub",
+      "sfdx-url-file",
+      "sfdx-url-stdin"
+    ],
     "flagChars": ["a", "d", "f", "p", "s"],
     "flagAliases": [
       "noprompt",

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -22,6 +22,10 @@ You can also create a JSON file that has a top-level property named sfdxAuthUrl 
 
 Path to a file that contains the Salesforce DX authorization URL.
 
+# flags.sfdx-url-stdin.summary
+
+Read sfdx auth url from stdin
+
 # examples
 
 - Authorize an org using the SFDX authorization URL in the files/authFile.json file:
@@ -31,3 +35,7 @@ Path to a file that contains the Salesforce DX authorization URL.
 - Similar to previous example, but set the org as your default and give it an alias MyDefaultOrg:
 
   <%= config.bin %> <%= command.id %> --sfdx-url-file files/authFile.json --set-default --alias MyDefaultOrg
+
+- Authorize an org reading the SFDX authorization URL from stdin:
+
+  echo 'force://PlatformCLI::CoffeeAndBacon@su0503.my.salesforce.com' | <%= config.bin %> <%= command.id %> --sfdx-url-stdin --set-default --alias MyDefaultOrg

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -26,6 +26,10 @@ Path to a file that contains the Salesforce DX authorization URL.
 
 Read sfdx auth url from stdin
 
+# errors.missingAuthUrl
+
+Error retrieving the auth URL. Please ensure it meets the description shown in the documentation for this command.
+
 # examples
 
 - Authorize an org using the SFDX authorization URL in the files/authFile.json file:

--- a/src/commands/org/login/sfdx-url.ts
+++ b/src/commands/org/login/sfdx-url.ts
@@ -88,9 +88,7 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
       : null;
 
     if (!sfdxAuthUrl) {
-      throw new Error(
-        'Error retrieving the auth URL. Please ensure it meets the description shown in the documentation for this command.'
-      );
+      throw messages.createError('errors.missingAuthUrl');
     }
 
     const oauth2Options = AuthInfo.parseSfdxAuthUrl(sfdxAuthUrl);

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export function read(): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const stdin = process.openStdin();
+    stdin.setEncoding('utf-8');
+
+    let data = '';
+    stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+
+    stdin.on('end', () => {
+      resolve(data);
+    });
+
+    if (stdin.isTTY) {
+      resolve('');
+    }
+  });
+}

--- a/test/commands/org/login/login.sfdx-url.nut.ts
+++ b/test/commands/org/login/login.sfdx-url.nut.ts
@@ -6,6 +6,7 @@
  */
 import { execCmd, prepareForAuthUrl, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
+import * as exec from 'shelljs';
 import { Env } from '@salesforce/kit';
 import { ensureString, getString } from '@salesforce/ts-types';
 import { AuthFields } from '@salesforce/core';
@@ -58,10 +59,7 @@ describe('org:login:sfdx-url NUTs', () => {
   });
 
   it('should authorize an org using sfdx-url (human readable)', () => {
-    env.setString('TESTKIT_EXECUTABLE_PATH', `echo '${authUrl}' | ${env.getString('TESTKIT_EXECUTABLE_PATH')}`);
-    const command = 'org:login:sfdx-url -d --sfdx-url-stdin';
-    const result = execCmd(command, { ensureExitCode: 0 });
-    const output = getString(result, 'shellOutput.stdout');
-    expect(output).to.include(`Successfully authorized ${username} with org ID`);
+    const res = exec.cat(authUrl).exec('bin/dev org:login:sfdx-url -d --sfdx-url-stdin', { silent: true });
+    expect(res.stdout).to.include(`Successfully authorized ${username} with org ID`);
   });
 });

--- a/test/commands/org/login/login.sfdx-url.nut.ts
+++ b/test/commands/org/login/login.sfdx-url.nut.ts
@@ -56,4 +56,12 @@ describe('org:login:sfdx-url NUTs', () => {
     const output = getString(result, 'shellOutput.stdout');
     expect(output).to.include(`Successfully authorized ${username} with org ID`);
   });
+
+  it('should authorize an org using sfdx-url (human readable)', () => {
+    env.setString('TESTKIT_EXECUTABLE_PATH', `echo '${authUrl}' | ${env.getString('TESTKIT_EXECUTABLE_PATH')}`);
+    const command = 'org:login:sfdx-url -d --sfdx-url-stdin';
+    const result = execCmd(command, { ensureExitCode: 0 });
+    const output = getString(result, 'shellOutput.stdout');
+    expect(output).to.include(`Successfully authorized ${username} with org ID`);
+  });
 });

--- a/test/commands/org/login/login.sfdx-url.test.ts
+++ b/test/commands/org/login/login.sfdx-url.test.ts
@@ -236,6 +236,19 @@ describe('org:login:sfdx-url', () => {
     }
   });
 
+  it('should throw error when not piping anything to stdin', async () => {
+    await prepareStubs({ fileDoesNotExist: true });
+    $$.SANDBOX.stub(stdin, 'read').resolves(undefined);
+    const store = new LoginSfdxUrl(['--sfdx-url-stdin', '--json'], {} as Config);
+
+    try {
+      const response = await store.run();
+      expect.fail(`Should have thrown an error. Response: ${JSON.stringify(response)}`);
+    } catch (e) {
+      expect((e as Error).message).to.includes('Error retrieving the auth URL');
+    }
+  });
+
   it('should throw error when passing both sfdx-url-stdin and sfdx-url-file', async () => {
     const store = new LoginSfdxUrl(['--sfdx-url-stdin', '--sfdx-url-file', 'path/to/key.txt', '--json'], {} as Config);
 

--- a/test/commands/org/login/login.sfdx-url.test.ts
+++ b/test/commands/org/login/login.sfdx-url.test.ts
@@ -8,7 +8,7 @@
 import * as fs from 'fs/promises';
 import { AuthFields, AuthInfo, Global, Mode } from '@salesforce/core';
 import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import { Config } from '@oclif/core';
 import { StubbedType, stubInterface } from '@salesforce/ts-sinon';
 import { SfCommand } from '@salesforce/sf-plugins-core';
@@ -247,6 +247,16 @@ describe('org:login:sfdx-url', () => {
     } catch (e) {
       expect((e as Error).message).to.includes('Error retrieving the auth URL');
     }
+  });
+
+  it('should ignore stdin when not using --sfdx-url-stdin', async () => {
+    await prepareStubs();
+    $$.SANDBOX.stub(stdin, 'read').resolves('force://foo::bar@su0503.my.salesforce.com');
+    const parseSfdxAuthUrlSpy = $$.SANDBOX.spy(AuthInfo, 'parseSfdxAuthUrl');
+    const store = new LoginSfdxUrl(['-f', keyPathTxt, '--json'], {} as Config);
+    await store.run();
+
+    assert.isTrue(parseSfdxAuthUrlSpy.calledWith('force://PlatformCLI::CoffeeAndBacon@su0503.my.salesforce.com'));
   });
 
   it('should throw error when passing both sfdx-url-stdin and sfdx-url-file', async () => {

--- a/test/commands/org/login/login.sfdx-url.test.ts
+++ b/test/commands/org/login/login.sfdx-url.test.ts
@@ -6,7 +6,7 @@
  */
 
 import * as fs from 'fs/promises';
-import { AuthFields, AuthInfo, Global, Mode } from '@salesforce/core';
+import { AuthFields, AuthInfo, Global, Mode, Messages } from '@salesforce/core';
 import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
 import { expect, assert } from 'chai';
 import { Config } from '@oclif/core';
@@ -14,6 +14,9 @@ import { StubbedType, stubInterface } from '@salesforce/ts-sinon';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 import LoginSfdxUrl from '../../../../src/commands/org/login/sfdx-url';
 import * as stdin from '../../../../src/stdin';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-auth', 'sfdxurl.store');
 
 interface Options {
   authInfoCreateFails?: boolean;
@@ -92,7 +95,7 @@ describe('org:login:sfdx-url', () => {
       const response = await store.run();
       expect.fail(`Should have thrown an error. Response: ${JSON.stringify(response)}`);
     } catch (e) {
-      expect((e as Error).message).to.includes('Error retrieving the auth URL');
+      expect((e as Error).message).to.includes(messages.getMessage('errors.missingAuthUrl'));
     }
   });
 
@@ -232,7 +235,7 @@ describe('org:login:sfdx-url', () => {
       const response = await store.run();
       expect.fail(`Should have thrown an error. Response: ${JSON.stringify(response)}`);
     } catch (e) {
-      expect((e as Error).message).to.includes('Error retrieving the auth URL');
+      expect((e as Error).message).to.includes(messages.getMessage('errors.missingAuthUrl'));
     }
   });
 
@@ -245,7 +248,7 @@ describe('org:login:sfdx-url', () => {
       const response = await store.run();
       expect.fail(`Should have thrown an error. Response: ${JSON.stringify(response)}`);
     } catch (e) {
-      expect((e as Error).message).to.includes('Error retrieving the auth URL');
+      expect((e as Error).message).to.includes(messages.getMessage('errors.missingAuthUrl'));
     }
   });
 

--- a/test/commands/org/login/login.sfdx-url.test.ts
+++ b/test/commands/org/login/login.sfdx-url.test.ts
@@ -223,6 +223,19 @@ describe('org:login:sfdx-url', () => {
     expect(response.username).to.equal(testData.username);
   });
 
+  it('should throw error when piping empty string to stdin', async () => {
+    await prepareStubs({ fileDoesNotExist: true });
+    $$.SANDBOX.stub(stdin, 'read').resolves('');
+    const store = new LoginSfdxUrl(['--sfdx-url-stdin', '--json'], {} as Config);
+
+    try {
+      const response = await store.run();
+      expect.fail(`Should have thrown an error. Response: ${JSON.stringify(response)}`);
+    } catch (e) {
+      expect((e as Error).message).to.includes('Error retrieving the auth URL');
+    }
+  });
+
   it('should throw error when passing both sfdx-url-stdin and sfdx-url-file', async () => {
     const store = new LoginSfdxUrl(['--sfdx-url-stdin', '--sfdx-url-file', 'path/to/key.txt', '--json'], {} as Config);
 


### PR DESCRIPTION
### What does this PR do?
With these changes developers can pipe the sfdx auth url from stdin as follows:

`echo 'force://PlatformCLI::CoffeeAndBacon@su0503.my.salesforce.com' | sfdx org:login:sfdx-url --sfdx-url-stdin`

Why? because it is not safe to store `force://<clientId>:<clientSecret>:<refreshToken>` in disk
inspired by https://docs.docker.com/engine/reference/commandline/login/ 

I know that this isnt really that useful because nobody is ever going to memorise these long numbers but at least it will discourage people from ever storing this info in files.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2120
[@W-13176733@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001R3fS8YAJ/view)