### PR TITLE
chore: update client secret prompt msg

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -46,7 +46,7 @@ Disable masking of user input; use with problematic terminals.
 
 # clientSecretStdin
 
-OAuth client secret of personal connected app?
+OAuth client secret of personal connected app? Press Enter if it is not required.
 
 # lightningInstanceUrl
 

--- a/messages/messages.md
+++ b/messages/messages.md
@@ -46,7 +46,7 @@ Disable masking of user input; use with problematic terminals.
 
 # clientSecretStdin
 
-OAuth client secret of personal connected app? Press Enter if it is not required.
+OAuth client secret of personal connected app? Press Enter if it's not required.
 
 # lightningInstanceUrl
 


### PR DESCRIPTION
### What does this PR do?
See internal slack thread:
https://salesforce-internal.slack.com/archives/G02K6C90RBJ/p1691780187618929

If you pass `--client-id` to use a custom connected app, `org login web` will prompt for the client secret but this can be skipped if `Require Secret for Web Server Flow enabled` is turned off in the app.
This PR updates the prompt msg to ask the user to just press enter if that's the case, the internal user confirmed this works.

### What issues does this PR fix or reference?
@W-13943313@