### PR TITLE
refactor: not  mutate authinfo.getFields object

### DIFF
--- a/src/commands/org/login/sfdx-url.ts
+++ b/src/commands/org/login/sfdx-url.ts
@@ -90,9 +90,8 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
       setDefaultDevHub: flags['set-default-dev-hub'],
     });
 
-    const result = authInfo.getFields(true);
     // ensure the clientSecret field... even if it is empty
-    result.clientSecret = result.clientSecret ?? '';
+    const result = { clientSecret: '', ...authInfo.getFields(true) };
     await AuthInfo.identifyPossibleScratchOrgs(result, authInfo);
 
     const successMsg = commonMessages.getMessage('authorizeCommandSuccess', [result.username, result.orgId]);


### PR DESCRIPTION
### What does this PR do?
@W-14085765@ will make AuthInfo.getFields readonly.  Preemptively prepare for that change so that we don't have to do it later and so that auth's tests can be used to valid the bigger configFile change safety.

### What issues does this PR fix or reference?
