### PR TITLE
refactor(types): remove jsforce imports

### DIFF
--- a/src/commands/org/login/device.ts
+++ b/src/commands/org/login/device.ts
@@ -5,8 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { OAuth2Config } from 'jsforce';
-import { AuthFields, AuthInfo, DeviceOauthService, Messages } from '@salesforce/core';
+import { AuthFields, AuthInfo, DeviceOauthService, Messages, OAuth2Config } from '@salesforce/core';
 import { Flags, loglevel } from '@salesforce/sf-plugins-core';
 import { DeviceCodeResponse } from '@salesforce/core/lib/deviceOauthService';
 import { ux } from '@oclif/core';

--- a/src/commands/org/login/web.ts
+++ b/src/commands/org/login/web.ts
@@ -8,8 +8,7 @@
 import * as open from 'open';
 
 import { Flags, loglevel } from '@salesforce/sf-plugins-core';
-import { OAuth2Config } from 'jsforce';
-import { AuthFields, AuthInfo, Logger, Messages, SfError, WebOAuthServer } from '@salesforce/core';
+import { AuthFields, AuthInfo, Logger, Messages, OAuth2Config, SfError, WebOAuthServer } from '@salesforce/core';
 import { Env } from '@salesforce/kit';
 import { Interfaces } from '@oclif/core';
 import { AuthBaseCommand } from '../../../authBaseCommand';


### PR DESCRIPTION
### What does this PR do?
import 1 type from sfdx-core instead of jsforce

### What issues does this PR fix or reference?
https://github.com/forcedotcom/sfdx-core/actions/runs/6535843735/job/17792534010