### PR TITLE
Add sfdx-url flag

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -82,16 +82,26 @@
   {
     "command": "org:login:sfdx-url",
     "plugin": "@salesforce/plugin-auth",
-    "flags": ["alias", "json", "loglevel", "no-prompt", "set-default", "set-default-dev-hub", "sfdx-url-file"],
+    "flags": [
+      "alias",
+      "json",
+      "loglevel",
+      "no-prompt",
+      "set-default",
+      "set-default-dev-hub",
+      "sfdx-url-file",
+      "sfdx-url"
+    ],
     "alias": ["force:auth:sfdxurl:store", "auth:sfdxurl:store"],
-    "flagChars": ["a", "d", "f", "p", "s"],
+    "flagChars": ["a", "d", "f", "p", "s", "u"],
     "flagAliases": [
       "noprompt",
       "setalias",
       "setdefaultdevhub",
       "setdefaultdevhubusername",
       "setdefaultusername",
-      "sfdxurlfile"
+      "sfdxurlfile",
+      "sfdxurl"
     ]
   },
   {

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -1,10 +1,12 @@
 # summary
 
-Authorize an org using a Salesforce DX authorization URL stored in a file.
+Authorize an org using a Salesforce DX authorization URL.
 
 # description
 
 The Salesforce DX (SFDX) authorization URL must have the format "%s". NOTE: The SFDX authorization URL uses the "force" protocol, and not "http" or "https". Also, the "instanceUrl" inside the SFDX authorization URL doesn't include the protocol ("https://").
+
+You can pass in the authorization URL using the --sfdx-url flag or by referencing a file path that contains the URL with the --sfdx-url-file flag.
 
 You have three options when creating the authorization file. The easiest option is to redirect the output of the "<%= config.bin %> org display --verbose --json" command into a file. For example, using an org with alias my-org that you've already authorized:
 

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -22,7 +22,15 @@ You can also create a JSON file that has a top-level property named sfdxAuthUrl 
 
 Path to a file that contains the Salesforce DX authorization URL.
 
+# flags.sfdx-url.summary
+
+The Salesforce DX authorization URL as a string.
+
 # examples
+
+- Authorize an org using the SFDX authorization URL passed in as a string:
+
+  <%= config.bin %> <%= command.id %> --sfdx-url force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>
 
 - Authorize an org using the SFDX authorization URL in the files/authFile.json file:
 

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -24,7 +24,7 @@ Path to a file that contains the Salesforce DX authorization URL.
 
 # flags.sfdx-url.summary
 
-The Salesforce DX authorization URL as a string.
+Salesforce DX authorization URL.
 
 # examples
 

--- a/src/commands/org/login/sfdx-url.ts
+++ b/src/commands/org/login/sfdx-url.ts
@@ -34,9 +34,15 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
     'sfdx-url-file': Flags.file({
       char: 'f',
       summary: messages.getMessage('flags.sfdx-url-file.summary'),
-      required: true,
+      required: false,
       deprecateAliases: true,
       aliases: ['sfdxurlfile'],
+    }),
+    'sfdx-url': Flags.string({
+      char: 'u',
+      summary: messages.getMessage('flags.sfdx-url.summary'),
+      required: false,
+      aliases: ['sfdxurl'],
     }),
     'set-default-dev-hub': Flags.boolean({
       char: 'd',
@@ -71,11 +77,26 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
     const { flags } = await this.parse(LoginSfdxUrl);
     if (await this.shouldExitCommand(flags['no-prompt'])) return {};
 
+    const authString = flags['sfdx-url'];
     const authFile = flags['sfdx-url-file'];
 
-    const sfdxAuthUrl = authFile.endsWith('.json')
-      ? await getUrlFromJson(authFile)
-      : await fs.readFile(authFile, 'utf8');
+    if (!authString && !authFile) {
+      throw new Error('Please include either the --sfdx-url or --sfdx-url-file flags.');
+    }
+
+    let sfdxAuthUrlVar;
+
+    if (authString) {
+      sfdxAuthUrlVar = authString;
+    }
+
+    if (!sfdxAuthUrlVar && authFile) {
+      sfdxAuthUrlVar = authFile.endsWith('.json')
+        ? await getUrlFromJson(authFile)
+        : await fs.readFile(authFile, 'utf8');
+    }
+
+    const sfdxAuthUrl = sfdxAuthUrlVar;
 
     if (!sfdxAuthUrl) {
       throw new Error(

--- a/test/commands/org/login/login.sfdx-url.test.ts
+++ b/test/commands/org/login/login.sfdx-url.test.ts
@@ -55,6 +55,25 @@ describe('org:login:sfdx-url', () => {
     }
   }
 
+  it('should return auth fields when passing in sfdxurl as string', async () => {
+    await prepareStubs();
+    const sfdxAuthUrl = 'force://PlatformCLI::CoffeeAndBacon@su0503.my.salesforce.com';
+    const store = new LoginSfdxUrl(['-u', sfdxAuthUrl], {} as Config);
+    const response = await store.run();
+    expect(response.username).to.equal(testData.username);
+  });
+
+  it('should error out when neither file or url are provided', async () => {
+    await prepareStubs();
+    const store = new LoginSfdxUrl([], {} as Config);
+    try {
+      const response = await store.run();
+      expect.fail(`Should have thrown an error. Response: ${JSON.stringify(response)}`);
+    } catch (e) {
+      expect((e as Error).message).to.includes('Please include either the --sfdx-url or --sfdx-url-file flags.');
+    }
+  });
+
   it('should return auth fields', async () => {
     await prepareStubs();
     const store = new LoginSfdxUrl(['-f', keyPathTxt, '--json'], {} as Config);


### PR DESCRIPTION
### What does this PR do?

- Adds a new flag (`-u, --sfdx-url`) for passing in the SFDX Authorization URL as a string instead of requiring it to be read from a file
- Prioritizes `--sfdx-url` over `--sfdx-url-file`
- Removes explicit requirement for -f flag, instead throws an error if neither `--sfdx-url` or `--sfdx-url-file` flag is referenced

#### Example
``$ sf org login sfdx-url --sfdx-url force://<clientId>:<clientSecret>:<refreshToken>@<instanceUrl>``

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/discussions/2586