### PR TITLE
feat: allow stdin for sfdx-url

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -82,16 +82,26 @@
   {
     "command": "org:login:sfdx-url",
     "plugin": "@salesforce/plugin-auth",
-    "flags": ["alias", "json", "loglevel", "no-prompt", "set-default", "set-default-dev-hub", "sfdx-url-file"],
+    "flags": [
+      "alias",
+      "json",
+      "loglevel",
+      "no-prompt",
+      "set-default",
+      "set-default-dev-hub",
+      "sfdx-url-file",
+      "sfdx-url-stdin"
+    ],
     "alias": ["force:auth:sfdxurl:store", "auth:sfdxurl:store"],
-    "flagChars": ["a", "d", "f", "p", "s"],
+    "flagChars": ["a", "d", "f", "p", "s", "u"],
     "flagAliases": [
       "noprompt",
       "setalias",
       "setdefaultdevhub",
       "setdefaultdevhubusername",
       "setdefaultusername",
-      "sfdxurlfile"
+      "sfdxurlfile",
+      "sfdxurlstdin"
     ]
   },
   {

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -1,6 +1,6 @@
 # summary
 
-Authorize an org using a Salesforce DX authorization URL stored in a file.
+Authorize an org using a Salesforce DX authorization URL stored in a file or through stdin.
 
 # description
 
@@ -20,7 +20,7 @@ You can also create a JSON file that has a top-level property named sfdxAuthUrl 
 
 # flags.sfdx-url-file.summary
 
-Path to a file that contains the Salesforce DX authorization URL.
+Path to a file that contains the Salesforce DX authorization URL. Use the '-' character to pipe through stdin.
 
 # examples
 
@@ -31,3 +31,7 @@ Path to a file that contains the Salesforce DX authorization URL.
 - Similar to previous example, but set the org as your default and give it an alias MyDefaultOrg:
 
   <%= config.bin %> <%= command.id %> --sfdx-url-file files/authFile.json --set-default --alias MyDefaultOrg
+
+- Pipe the SFDX authorization url from stdin by providing the '-' value.
+
+  $ echo $url | <%= config.bin %> <%= command.id %> --sfdx-url-file -

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -18,9 +18,15 @@ NOTE: The "<%= config.bin %> org display --verbose" command displays the refresh
 
 You can also create a JSON file that has a top-level property named sfdxAuthUrl whose value is the authorization URL. Finally, you can create a normal text file that includes just the URL and nothing else.
 
+Alternatively, you can pipe the SFDX authorization url through standard input by using the --sfdx-url-stdin flag and providing the '-' character as the value.
+
 # flags.sfdx-url-file.summary
 
-Path to a file that contains the Salesforce DX authorization URL. Use the '-' character to pipe the value through standard input (stdin).
+Path to a file that contains the Salesforce DX authorization URL.
+
+# flags.sfdx-url-stdin.summary
+
+Provide '-' as the value to pipe the Salesforce DX authorization URL through standard input (stdin).
 
 # examples
 
@@ -34,4 +40,4 @@ Path to a file that contains the Salesforce DX authorization URL. Use the '-' ch
 
 - Pipe the SFDX authorization URL from stdin by specifying the '-' value.
 
-  echo $url | <%= config.bin %> <%= command.id %> --sfdx-url-file -
+  <%= "\n $ echo url | " + config.bin %> <%= command.id %> --sfdx-url-stdin -

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -26,7 +26,7 @@ Path to a file that contains the Salesforce DX authorization URL.
 
 # flags.sfdx-url-stdin.summary
 
-Provide '-' as the value to pipe the Salesforce DX authorization URL through standard input (stdin).
+Specify '-' as this flag's value to pipe the Salesforce DX authorization URL through standard input (stdin).
 
 # examples
 

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -18,7 +18,7 @@ NOTE: The "<%= config.bin %> org display --verbose" command displays the refresh
 
 You can also create a JSON file that has a top-level property named sfdxAuthUrl whose value is the authorization URL. Finally, you can create a normal text file that includes just the URL and nothing else.
 
-Alternatively, you can pipe the SFDX authorization url through standard input by using the --sfdx-url-stdin flag and providing the '-' character as the value.
+Alternatively, you can pipe the SFDX authorization URL through standard input by using the --sfdx-url-stdin flag and providing the '-' character as the value.
 
 # flags.sfdx-url-file.summary
 

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -1,6 +1,6 @@
 # summary
 
-Authorize an org using a Salesforce DX authorization URL stored in a file or through stdin.
+Authorize an org using a Salesforce DX authorization URL stored in a file or through standard input (stdin).
 
 # description
 

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -20,7 +20,7 @@ You can also create a JSON file that has a top-level property named sfdxAuthUrl 
 
 # flags.sfdx-url-file.summary
 
-Path to a file that contains the Salesforce DX authorization URL. Use the '-' character to pipe through stdin.
+Path to a file that contains the Salesforce DX authorization URL. Use the '-' character to pipe the value through standard input (stdin).
 
 # examples
 

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -32,6 +32,6 @@ Path to a file that contains the Salesforce DX authorization URL. Use the '-' ch
 
   <%= config.bin %> <%= command.id %> --sfdx-url-file files/authFile.json --set-default --alias MyDefaultOrg
 
-- Pipe the SFDX authorization url from stdin by providing the '-' value.
+- Pipe the SFDX authorization URL from stdin by specifying the '-' value.
 
   $ echo $url | <%= config.bin %> <%= command.id %> --sfdx-url-file -

--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -34,4 +34,4 @@ Path to a file that contains the Salesforce DX authorization URL. Use the '-' ch
 
 - Pipe the SFDX authorization URL from stdin by specifying the '-' value.
 
-  $ echo $url | <%= config.bin %> <%= command.id %> --sfdx-url-file -
+  echo $url | <%= config.bin %> <%= command.id %> --sfdx-url-file -

--- a/src/commands/org/login/sfdx-url.ts
+++ b/src/commands/org/login/sfdx-url.ts
@@ -93,12 +93,6 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
       }
     } else if (authStdin) {
       sfdxAuthUrl = authStdin;
-
-      if (!sfdxAuthUrl) {
-        throw new Error(
-          'Error getting the auth URL from stdin. Please ensure it meets the description shown in the documentation for this command.'
-        );
-      }
     } else {
       throw new Error('Please include either the --sfdx-url-stdin or --sfdx-url-file flags.');
     }

--- a/src/commands/org/login/sfdx-url.ts
+++ b/src/commands/org/login/sfdx-url.ts
@@ -37,6 +37,7 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
       required: true,
       deprecateAliases: true,
       aliases: ['sfdxurlfile'],
+      allowStdin: true,
     }),
     'set-default-dev-hub': Flags.boolean({
       char: 'd',
@@ -71,11 +72,18 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
     const { flags } = await this.parse(LoginSfdxUrl);
     if (await this.shouldExitCommand(flags['no-prompt'])) return {};
 
-    const authFile = flags['sfdx-url-file'];
+    const authFile: string = flags['sfdx-url-file'];
+    let sfdxAuthUrl: string;
 
-    const sfdxAuthUrl = authFile.endsWith('.json')
-      ? await getUrlFromJson(authFile)
-      : await fs.readFile(authFile, 'utf8');
+    const match = authFile.match(
+      /^force:\/\/([a-zA-Z0-9._-]+={0,2}):([a-zA-Z0-9._-]*={0,2}):([a-zA-Z0-9._-]+={0,2})@([a-zA-Z0-9._-]+)/
+    );
+
+    if (match) {
+      sfdxAuthUrl = authFile;
+    } else {
+      sfdxAuthUrl = authFile.endsWith('.json') ? await getUrlFromJson(authFile) : await fs.readFile(authFile, 'utf8');
+    }
 
     if (!sfdxAuthUrl) {
       throw new Error(

--- a/src/commands/org/login/sfdx-url.ts
+++ b/src/commands/org/login/sfdx-url.ts
@@ -36,6 +36,8 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
       required: false,
       deprecateAliases: true,
       aliases: ['sfdxurlfile'],
+      exactlyOne: ['sfdx-url-file', 'sfdx-url-stdin'],
+      exclusive: ['sfdx-url-stdin'],
     }),
     'sfdx-url-stdin': Flags.file({
       char: 'u',
@@ -44,6 +46,8 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
       deprecateAliases: true,
       aliases: ['sfdxurlstdin'],
       allowStdin: 'only',
+      exactlyOne: ['sfdx-url-file', 'sfdx-url-stdin'],
+      exclusive: ['sfdx-url-file'],
     }),
     'set-default-dev-hub': Flags.boolean({
       char: 'd',
@@ -93,7 +97,7 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
     } else if (authStdin) {
       sfdxAuthUrl = authStdin;
     } else {
-      throw new Error('Please include either the --sfdx-url-stdin or --sfdx-url-file flags.');
+      throw new Error('SFDX Auth URL not found.');
     }
 
     const oauth2Options = AuthInfo.parseSfdxAuthUrl(sfdxAuthUrl);

--- a/src/commands/org/login/sfdx-url.ts
+++ b/src/commands/org/login/sfdx-url.ts
@@ -37,7 +37,6 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
       deprecateAliases: true,
       aliases: ['sfdxurlfile'],
       exactlyOne: ['sfdx-url-file', 'sfdx-url-stdin'],
-      exclusive: ['sfdx-url-stdin'],
     }),
     'sfdx-url-stdin': Flags.file({
       char: 'u',
@@ -47,7 +46,6 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
       aliases: ['sfdxurlstdin'],
       allowStdin: 'only',
       exactlyOne: ['sfdx-url-file', 'sfdx-url-stdin'],
-      exclusive: ['sfdx-url-file'],
     }),
     'set-default-dev-hub': Flags.boolean({
       char: 'd',

--- a/src/commands/org/login/sfdx-url.ts
+++ b/src/commands/org/login/sfdx-url.ts
@@ -43,7 +43,7 @@ export default class LoginSfdxUrl extends AuthBaseCommand<AuthFields> {
       required: false,
       deprecateAliases: true,
       aliases: ['sfdxurlstdin'],
-      allowStdin: true,
+      allowStdin: 'only',
     }),
     'set-default-dev-hub': Flags.boolean({
       char: 'd',

--- a/test/commands/org/login/login.sfdx-url.test.ts
+++ b/test/commands/org/login/login.sfdx-url.test.ts
@@ -221,7 +221,9 @@ describe('org:login:sfdx-url', () => {
       const response = await store.run();
       expect.fail(`Should have thrown an error. Response: ${JSON.stringify(response)}`);
     } catch (e) {
-      expect((e as Error).message).to.includes('Please include either the --sfdx-url-stdin or --sfdx-url-file flags.');
+      expect((e as Error).message).to.includes(
+        'Exactly one of the following must be provided: --sfdx-url-file, --sfdx-url-stdin'
+      );
     }
   });
 


### PR DESCRIPTION
### What does this PR do?

- oclif has been updated to include a new option for flags: `allowStdin`
- Another oclif update allows a flag to be designated as stdin 'only', meaning that it will error out if anything other than the '-' value is provided
- A new flag has been introduced per recommendation called `--sfdx-url-stdin` and has `allowStdin: 'only'`
- This means `--sfdx-url-file` is no longer required, so an error is thrown if neither `--sfdx-url-stdin` or `--sfdx-url-file` are given
- Original discussion on this solution found here: https://github.com/oclif/core/issues/761

`$ echo url | sf org login sfdx-url --sfdx-url-stdin -`


### What issues does this PR fix or reference?
closes: https://github.com/forcedotcom/cli/issues/2120
[skip-validate-pr]