### PR TITLE
fix: update help after "-" no longer required for --sfdx-url-stdin

### DIFF
--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -18,7 +18,7 @@ NOTE: The "<%= config.bin %> org display --verbose" command displays the refresh
 
 You can also create a JSON file that has a top-level property named sfdxAuthUrl whose value is the authorization URL. Finally, you can create a normal text file that includes just the URL and nothing else.
 
-Alternatively, you can pipe the SFDX authorization URL through standard input by using the --sfdx-url-stdin flag and providing the '-' character as the value.
+Alternatively, you can pipe the SFDX authorization URL through standard input by specifying the --sfdx-url-stdin flag.
 
 # flags.sfdx-url-file.summary
 
@@ -26,7 +26,7 @@ Path to a file that contains the Salesforce DX authorization URL.
 
 # flags.sfdx-url-stdin.summary
 
-Specify '-' as this flag's value to pipe the Salesforce DX authorization URL through standard input (stdin).
+Pipe the Salesforce DX authorization URL through standard input (stdin).
 
 # examples
 
@@ -38,6 +38,6 @@ Specify '-' as this flag's value to pipe the Salesforce DX authorization URL thr
 
   <%= config.bin %> <%= command.id %> --sfdx-url-file files/authFile.json --set-default --alias MyDefaultOrg
 
-- Pipe the SFDX authorization URL from stdin by specifying the '-' value.
+- Pipe the SFDX authorization URL from stdin:
 
-  <%= "\n $ echo url | " + config.bin %> <%= command.id %> --sfdx-url-stdin -
+  <%= "\n $ echo url | " + config.bin %> <%= command.id %> --sfdx-url-stdin


### PR DESCRIPTION
### What does this PR do?

Updates help after "-" no longer required for --sfdx-url-stdin flag

### What issues does this PR fix or reference?

@W-@
