### PR TITLE
fix: typo in piping URL example

### DIFF
--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -40,4 +40,4 @@ Pipe the Salesforce DX authorization URL through standard input (stdin).
 
 - Pipe the SFDX authorization URL from stdin:
 
-  <%= "\n $ echo url | " + config.bin %> <%= command.id %> --sfdx-url-stdin
+  $ echo url | sf <%= command.id %> --sfdx-url-stdin


### PR DESCRIPTION
### What does this PR do?

hard codes part of the piping-URL example so that it renders correctly in the generated Command Reference.  This hard codes a "$" prompt in the DITA, which is frowned upon by CX, but because this is an exception to how we normally print the examples, I'm gonna allow it just this once. 

### What issues does this PR fix or reference?
@W-15454019@