### PR TITLE
fix: wrap JwtGrantErrors

### DIFF
--- a/src/commands/org/login/jwt.ts
+++ b/src/commands/org/login/jwt.ts
@@ -99,10 +99,12 @@ export default class LoginJwt extends SfCommand<AuthFields> {
       result = authInfo.getFields(true);
       await AuthInfo.identifyPossibleScratchOrgs(result, authInfo);
     } catch (err) {
-      if (!(err instanceof Error)) {
-        throw err;
-      }
-      throw messages.createError('JwtGrantError', [err.message]);
+      const msg = err instanceof Error ? `${err.name}::${err.message}` : typeof err === 'string' ? err : 'UNKNOWN';
+      throw SfError.create({
+        message: messages.getMessage('JwtGrantError', [msg]),
+        name: 'JwtGrantError',
+        ...(err instanceof Error ? { cause: err } : {}),
+      });
     }
 
     const successMsg = commonMessages.getMessage('authorizeCommandSuccess', [result.username, result.orgId]);

--- a/test/commands/org/login/login.jwt.nut.ts
+++ b/test/commands/org/login/login.jwt.nut.ts
@@ -56,4 +56,19 @@ describe('org:login:jwt NUTs', () => {
     const output = getString(result, 'shellOutput.stdout');
     expect(output).to.include(`Successfully authorized ${username} with org ID`);
   });
+
+  it('should throw correct error for JwtAuthError', () => {
+    const command = `org:login:jwt -d -o ${username} -i incorrect -f ${jwtKey} -r ${instanceUrl} --json`;
+    const json = execCmd(command).jsonOutput;
+    expect(json).to.have.property('name', 'JwtGrantError');
+    expect(json).to.have.property('exitCode', 1);
+    expect(json)
+      .to.have.property('message')
+      .and.include(
+        'We encountered a JSON web token error, which is likely not an issue with Salesforce CLI. Here’s the error: JwtAuthError::Error authenticating with JWT.'
+      );
+    expect(json).to.have.property('stack').and.include('client identifier invalid');
+    expect(json).to.have.property('cause').and.include('SfError [JwtAuthError]: Error authenticating with JWT.');
+    expect(json).to.have.property('cause').and.include('at AuthInfo.authJwt');
+  });
 });

--- a/test/commands/org/login/login.jwt.test.ts
+++ b/test/commands/org/login/login.jwt.test.ts
@@ -184,7 +184,11 @@ describe('org:login:jwt', () => {
       await LoginJwt.run(['-u', testData.username, '-f', 'path/to/key.json', '-i', '123456INVALID', '--json']);
       expect.fail('Should have thrown an error');
     } catch (e) {
-      expect((e as Error).message).to.include('We encountered a JSON web token error');
+      expect(e).to.be.instanceOf(SfError);
+      const jwtAuthError = e as SfError;
+      expect(jwtAuthError.message).to.include('We encountered a JSON web token error');
+      expect(jwtAuthError.message).to.include('invalid client id');
+      expect(jwtAuthError.cause, 'JwtAuthErrors should include original error as the cause').to.be.ok;
     }
   });
 


### PR DESCRIPTION
### What does this PR do?
Wraps any error that happens during JWT auth in a JwtGrantError to retain the original cause and stack.  Augments existing unit test.  Adds new NUT.

### What issues does this PR fix or reference?
@W-16395441@

To test:
Use a current version of the CLI to `org login jwt` with an incorrect client ID using `--json` and without `--json`.  Note the result and compare with a locally built plugin-auth.  The fixed plugin should retain all the error information and include an error `cause`.