### PR TITLE
clarify help for "org login sfdx-url" regarding force:// vs. https://

### DIFF
--- a/messages/sfdxurl.store.md
+++ b/messages/sfdxurl.store.md
@@ -4,7 +4,9 @@ Authorize an org using a Salesforce DX authorization URL stored in a file or thr
 
 # description
 
-The Salesforce DX (SFDX) authorization URL must have the format "%s". NOTE: The SFDX authorization URL uses the "force" protocol, and not "http" or "https". Also, the "instanceUrl" inside the SFDX authorization URL doesn't include the protocol ("https://").
+You use the Salesforce DX (SFDX) authorization URL to authorize Salesforce CLI to connect to a target org. The URL contains the required data to accomplish the authorization, such as the client ID, client secret, and instance URL. You must specify the SFDX authorization URL in this format: "%s". Replace <clientId>, <clientSecret>, <refreshToken>, and <instanceUrl> with the values specific to your target org. For <instanceUrl>, don't include a protocol (such as "https://"). Note that although the SFDX authorization URL starts with "force://", it has nothing to do with the actual authorization. Salesforce CLI always communicates with your org using HTTPS.
+
+To see an example of an SFDX authorization URL, run "org display --verbose" on an org.
 
 You have three options when creating the authorization file. The easiest option is to redirect the output of the "<%= config.bin %> org display --verbose --json" command into a file. For example, using an org with alias my-org that you've already authorized:
 

--- a/src/commands/org/login/sfdx-url.ts
+++ b/src/commands/org/login/sfdx-url.ts
@@ -89,13 +89,13 @@ export default class LoginSfdxUrl extends SfCommand<AuthFields> {
 
       if (!sfdxAuthUrl) {
         throw new Error(
-          `Error getting the auth URL from file ${authFile}. Please ensure it meets the description shown in the documentation for this command.`
+          `Error getting the SFDX authorization URL from file ${authFile}. Ensure it meets the description shown in the documentation (--help) for this command.`
         );
       }
     } else if (authStdin) {
       sfdxAuthUrl = authStdin;
     } else {
-      throw new Error('SFDX Auth URL not found.');
+      throw new Error('SFDX authorization URL not found.');
     }
 
     const oauth2Options = AuthInfo.parseSfdxAuthUrl(sfdxAuthUrl);

--- a/test/commands/org/login/login.sfdx-url.test.ts
+++ b/test/commands/org/login/login.sfdx-url.test.ts
@@ -92,7 +92,7 @@ describe('org:login:sfdx-url', () => {
       const response = await LoginSfdxUrl.run(['-f', keyPathJson, '--json']);
       expect.fail(`Should have thrown an error. Response: ${JSON.stringify(response)}`);
     } catch (e) {
-      expect((e as Error).message).to.includes('Error getting the auth URL from file');
+      expect((e as Error).message).to.includes('Error getting the SFDX authorization URL from file');
     }
   });
 


### PR DESCRIPTION
### What does this PR do?
Updates info about SFDX auth URL to explain that the auth still happens over HTTPS, even though the auth url starts with "force://".   

### What issues does this PR fix or reference?
@W-16716321@
