### PR TITLE
fix(web login): throw if can't open browser W-17969693

### DIFF
--- a/messages/web.login.md
+++ b/messages/web.login.md
@@ -49,3 +49,11 @@ If you don’t specify --browser, the command uses your default browser. The exa
 # invalidClientId
 
 Invalid client credentials. Verify the OAuth client secret and ID. %s
+
+# error.cannotOpenBrowser
+
+Unable to open %s.
+
+# error.cannotOpenBrowser.actions
+
+- Ensure %s is installed.

--- a/messages/web.login.md
+++ b/messages/web.login.md
@@ -52,8 +52,8 @@ Invalid client credentials. Verify the OAuth client secret and ID. %s
 
 # error.cannotOpenBrowser
 
-Unable to open %s.
+Unable to open the browser you specified (%s).
 
 # error.cannotOpenBrowser.actions
 
-- Ensure %s is installed.
+- Ensure that %s is installed on your computer. Or specify a different browser using the --browser flag.

--- a/src/commands/org/login/web.ts
+++ b/src/commands/org/login/web.ts
@@ -116,7 +116,12 @@ export default class LoginWeb extends SfCommand<AuthFields> {
     await oauthServer.start();
     const app = browser && browser in apps ? (browser as AppName) : undefined;
     const openOptions = app ? { app: { name: apps[app] }, wait: false } : { wait: false };
-    await open(oauthServer.getAuthorizationUrl(), openOptions);
+    const childProcess = await open(oauthServer.getAuthorizationUrl(), openOptions);
+    childProcess.on('exit', (code) => {
+      if (code && code > 0) {
+        throw messages.createError('error.cannotOpenBrowser', [app], [app]);
+      }
+    });
     return oauthServer.authorizeAndSave();
   }
 }

--- a/src/commands/org/login/web.ts
+++ b/src/commands/org/login/web.ts
@@ -71,6 +71,8 @@ export default class LoginWeb extends SfCommand<AuthFields> {
     loglevel,
   };
 
+  private logger = Logger.childFromRoot(this.constructor.name);
+
   public async run(): Promise<AuthFields> {
     const { flags } = await this.parse(LoginWeb);
     if (isContainerMode()) {
@@ -116,12 +118,26 @@ export default class LoginWeb extends SfCommand<AuthFields> {
     await oauthServer.start();
     const app = browser && browser in apps ? (browser as AppName) : undefined;
     const openOptions = app ? { app: { name: apps[app] }, wait: false } : { wait: false };
-    const childProcess = await open(oauthServer.getAuthorizationUrl(), openOptions);
-    childProcess.on('exit', (code) => {
-      if (code && code > 0) {
-        throw messages.createError('error.cannotOpenBrowser', [app], [app]);
-      }
-    });
+    this.logger.debug(`Opening browser ${app ?? ''}`);
+    // the following `childProcess` wrapper is needed to catch when `open` fails to open a browser.
+    await open(oauthServer.getAuthorizationUrl(), openOptions).then(
+      (childProcess) =>
+        new Promise((resolve, reject) => {
+          // https://nodejs.org/api/child_process.html#event-exit
+          childProcess.on('exit', (code) => {
+            if (code && code > 0) {
+              this.logger.debug(`Failed to open browser ${app ?? ''}`);
+              reject(messages.createError('error.cannotOpenBrowser', [app], [app]));
+            }
+            // If the process exited, code is the final exit code of the process, otherwise null.
+            // resolve on null just to be safe, worst case the browser didn't open and the CLI just hangs.
+            if (code === null || code === 0) {
+              this.logger.debug(`Successfully opened browser ${app ?? ''}`);
+              resolve(childProcess);
+            }
+          });
+        })
+    );
     return oauthServer.authorizeAndSave();
   }
 }


### PR DESCRIPTION
### What does this PR do?
Check if the child process returned by `open` in `org login web` emits the `exit` event and throw if it includes an exit code > 0 (the platform-dependant open command failed to open the browser).

On macos, we get the following error:
```
➜  ~ open -a 'microsoft edge'
Unable to find application named 'microsoft edge'
```

but no `error` event is emitted and `exit` only includes the exit code so we can't offer more info about why `open` failed.

docs:
https://nodejs.org/api/child_process.html#event-exit

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1830
@W-17969693@