### PR TITLE
fix: bump core dependency to 8.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@inquirer/checkbox": "^2.5.0",
     "@inquirer/select": "^2.5.0",
     "@oclif/core": "^4",
-    "@salesforce/core": "^8.18.7",
+    "@salesforce/core": "^8.20.0",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/plugin-info": "^3.4.80",
     "@salesforce/sf-plugins-core": "^12.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1542,6 +1542,31 @@
     semver "^7.6.3"
     ts-retry-promise "^0.8.1"
 
+"@salesforce/core@^8.20.0":
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.20.0.tgz#3a63ae04a9fd70ac10123013d3cbf7488a798033"
+  integrity sha512-WZoab9aHDbYXUh4nO+91PNLHpiPfK408qjn3l6Sbgck2d0bzYkW5wOmuv5D5yWrEybs9kGosrW/e9liKPGmgng==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.10.1"
+    "@salesforce/kit" "^3.2.2"
+    "@salesforce/schemas" "^1.9.1"
+    "@salesforce/ts-types" "^2.0.11"
+    ajv "^8.17.1"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.0"
+    form-data "^4.0.4"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    memfs "^4.30.1"
+    pino "^9.7.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.3.0"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.3"
+    ts-retry-promise "^0.8.1"
+
 "@salesforce/dev-config@^4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@salesforce/dev-config/-/dev-config-4.3.1.tgz#4dac8245df79d675258b50e1d24e8c636eaa5e10"


### PR DESCRIPTION
### What does this PR do?
bump core dependency to 8.20.0

[skip-validate-pr]
