### PR TITLE
fix org logout with fail username/alias-W-19385476

### DIFF
--- a/messages/logout.md
+++ b/messages/logout.md
@@ -98,6 +98,6 @@ You must specify a target-org (or default target-org config is set) or use --all
 
 You must specify a target-org (or default target-org config is set) or use --all flag when using the --json flag.
 
-# noOrgFoundForTarget
+# noAuthFoundForTargetOrg
 
 No authenticated org found with the %s username or alias.

--- a/messages/logout.md
+++ b/messages/logout.md
@@ -44,7 +44,7 @@ All orgs includes Dev Hubs, sandboxes, DE orgs, and expired, deleted, and unknow
 
 # flags.client-app.summary
 
-Client app to log out of. 
+Client app to log out of.
 
 # logoutOrgCommandSuccess
 
@@ -98,8 +98,6 @@ You must specify a target-org (or default target-org config is set) or use --all
 
 You must specify a target-org (or default target-org config is set) or use --all flag when using the --json flag.
 
-# warning.NoAuthFoundForTargetOrg
+# noOrgFoundForTarget
 
 No authenticated org found with the %s username or alias.
-
-NOTE: Starting September 2025, this warning will be converted to an error. As a result, the exit code when you try to log out of an unauthenticated org will change from 0 to 1.

--- a/src/commands/org/logout.ts
+++ b/src/commands/org/logout.ts
@@ -98,10 +98,8 @@ export default class Logout extends SfCommand<AuthLogoutResults> {
 
     if (orgAuths.length === 0) {
       if (flags['target-org']) {
-        this.warn(messages.createWarning('warning.NoAuthFoundForTargetOrg', [flags['target-org']]));
-        // user specified a target org but it was not resolved, issue success message and return
-        this.logSuccess(messages.getMessage('logoutOrgCommandSuccess', [flags['target-org']]));
-        return [flags['target-org']];
+        // user specified a target org but it was not resolved, throw error
+        throw messages.createError('noOrgFoundForTarget', [flags['target-org']]);
       }
       this.info(messages.getMessage('noOrgsFound'));
       return [];

--- a/src/commands/org/logout.ts
+++ b/src/commands/org/logout.ts
@@ -99,7 +99,7 @@ export default class Logout extends SfCommand<AuthLogoutResults> {
     if (orgAuths.length === 0) {
       if (flags['target-org']) {
         // user specified a target org but it was not resolved, throw error
-        throw messages.createError('noOrgFoundForTarget', [flags['target-org']]);
+        throw messages.createError('noAuthFoundForTargetOrg', [flags['target-org']]);
       }
       this.info(messages.getMessage('noOrgsFound'));
       return [];

--- a/test/commands/org/login/login.jwt.nut.ts
+++ b/test/commands/org/login/login.jwt.nut.ts
@@ -35,10 +35,6 @@ describe('org:login:jwt NUTs', () => {
     await testSession?.clean();
   });
 
-  afterEach(() => {
-    execCmd(`auth:logout -p -o ${username}`, { ensureExitCode: 0 });
-  });
-
   it('should authorize an org using jwt (json)', () => {
     const command = `org:login:jwt -d -o ${username} -i ${clientId} -f ${jwtKey} -r ${instanceUrl} --json`;
     const json = execCmd<AuthFields>(command, { ensureExitCode: 0 }).jsonOutput?.result as AuthFields;
@@ -48,6 +44,7 @@ describe('org:login:jwt NUTs', () => {
     expectUrlToExist(json, 'loginUrl');
     expect(json.privateKey).to.equal(path.join(testSession.homeDir, 'jwtKey'));
     expect(json.username).to.equal(username);
+    execCmd(`auth:logout -p -o ${username}`, { ensureExitCode: 0 });
   });
 
   it('should authorize an org using jwt (human readable)', () => {
@@ -55,6 +52,7 @@ describe('org:login:jwt NUTs', () => {
     const result = execCmd(command, { ensureExitCode: 0 });
     const output = getString(result, 'shellOutput.stdout');
     expect(output).to.include(`Successfully authorized ${username} with org ID`);
+    execCmd(`auth:logout -p -o ${username}`, { ensureExitCode: 0 });
   });
 
   it('should throw correct error for JwtAuthError', () => {

--- a/test/commands/org/logout.test.ts
+++ b/test/commands/org/logout.test.ts
@@ -161,7 +161,7 @@ describe('org:logout', () => {
       await Logout.run(['-p', '-o', testOrg1.username, '--json']);
       expect.fail('Expected error to be thrown');
     } catch (e) {
-      expect((e as Error).name).to.equal('NoOrgFoundForTargetError');
+      expect((e as Error).name).to.equal('NoAuthFoundForTargetOrgError');
       expect((e as Error).message).to.include('No authenticated org found');
     }
   });

--- a/test/commands/org/logout.test.ts
+++ b/test/commands/org/logout.test.ts
@@ -157,7 +157,12 @@ describe('org:logout', () => {
       aliases: { TestAlias: testOrg1.username },
       authInfoConfigDoesNotExist: true,
     });
-    const response = await Logout.run(['-p', '-o', testOrg1.username, '--json']);
-    expect(response).to.deep.equal([testOrg1.username]);
+    try {
+      await Logout.run(['-p', '-o', testOrg1.username, '--json']);
+      expect.fail('Expected error to be thrown');
+    } catch (e) {
+      expect((e as Error).name).to.equal('NoOrgFoundForTargetError');
+      expect((e as Error).message).to.include('No authenticated org found');
+    }
   });
 });


### PR DESCRIPTION
### What does this PR do?
Remove warning message
throw an error when user using `org logout `without authenticated org correctly.
### What issues does this PR fix or reference?
@W-19385476@

warning PR: https://github.com/salesforcecli/plugin-auth/pull/1282
