### PR TITLE
fix: use execFile instead of exec for npm calls-W-23661850

### DIFF
--- a/src/hooks/diagnostics.ts
+++ b/src/hooks/diagnostics.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import childProcess from 'node:child_process';
-import { ExecOptions, PromiseWithChild } from 'node:child_process';
+import { ExecFileOptions } from 'node:child_process';
 import util from 'node:util';
 import { join } from 'node:path';
 import fs from 'node:fs';
@@ -24,7 +24,11 @@ import { asString, isString } from '@salesforce/ts-types';
 import { parseJsonMap } from '@salesforce/kit';
 
 type HookFunction = (options: { doctor: SfDoctor }) => Promise<[void]>;
-type PromisifiedExec = (command: string, options?: ExecOptions) => PromiseWithChild<{ stdout: string; stderr: string }>;
+type PromisifiedExecFile = (
+  command: string,
+  args: string[],
+  options?: ExecFileOptions
+) => Promise<{ stdout: string; stderr: string }>;
 
 let logger: Logger;
 const getLogger = (): Logger => {
@@ -38,13 +42,15 @@ const pluginName = '@salesforce/plugin-auth';
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages(pluginName, 'diagnostics');
 
-let exec: PromisifiedExec;
+// Use execFile instead of exec to avoid shell interpretation.
+// exec invokes cmd.exe on Windows, which resolves commands from CWD before PATH.
+let execFile: PromisifiedExecFile;
 
 export const hook: HookFunction = async (options) => {
   getLogger().debug(`Running SfDoctor diagnostics for ${pluginName}`);
-  exec = util.promisify(childProcess.exec);
+  execFile = util.promisify(childProcess.execFile) as unknown as PromisifiedExecFile;
   try {
-    await exec('npm -v');
+    await execFile('npm', ['-v']);
     return await Promise.all([cryptoVersionTest(options.doctor)]);
   } catch (e: unknown) {
     const errMsg = e instanceof Error ? e.message : isString(e) ? e : 'unknown';
@@ -153,7 +159,7 @@ const supportsCliV2Crypto = async (doctor: SfDoctor): Promise<boolean> => {
   // check core CLI
   if (root?.length) {
     try {
-      const { stdout } = await exec('npm explain @salesforce/core --json', { cwd: root });
+      const { stdout } = await execFile('npm', ['explain', '@salesforce/core', '--json'], { cwd: root });
       const coreExplanation = JSON.parse(stdout) as NpmExplanation[];
       coreSupportsV2 = coreExplanation.every((exp) => exp?.version > '6.6.0');
     } catch (e: unknown) {
@@ -164,7 +170,7 @@ const supportsCliV2Crypto = async (doctor: SfDoctor): Promise<boolean> => {
   // check installed plugins
   if (dataDir?.length) {
     try {
-      const { stdout } = await exec('npm explain @salesforce/core --json', { cwd: dataDir });
+      const { stdout } = await execFile('npm', ['explain', '@salesforce/core', '--json'], { cwd: dataDir });
       const pluginsExplanation = JSON.parse(stdout) as NpmExplanation[];
       pluginsSupportV2 = pluginsExplanation?.length ? pluginsExplanation.every((exp) => exp?.version > '6.6.0') : true;
     } catch (e: unknown) {
@@ -186,7 +192,7 @@ const supportsCliV2Crypto = async (doctor: SfDoctor): Promise<boolean> => {
           // last entry is the path. E.g., "auth 3.3.17 (link) /Users/me/dev/plugin-auth",
           const pluginPath = pluginEntry.split(' ')?.pop();
           if (pluginPath?.length) {
-            const { stdout } = await exec('npm explain @salesforce/core --json', { cwd: pluginPath });
+            const { stdout } = await execFile('npm', ['explain', '@salesforce/core', '--json'], { cwd: pluginPath });
             const linksExplanation = JSON.parse(stdout) as NpmExplanation[];
             return linksExplanation?.every((exp) => exp?.version > '6.6.0');
           }


### PR DESCRIPTION
### What does this PR do?
 ## Summary
  - Use `execFile` instead of `exec` for npm shell calls in diagnostics hook
  - `exec` spawns a shell (cmd.exe on Windows), which resolves commands from CWD before PATH
  - Both `plugin-info` and `plugin-auth` fixes are required — `sf doctor` triggers diagnostics hooks in both plugins

  ## Test plan
  - [x] Existing unit tests pass
  - [x] Verified on Windows VM — CWD-local npm.cmd no longer executes
  - [x] Verified on macOS — `sf doctor` works normally
### What issues does this PR fix or reference?
plugin-info PR: https://github.com/salesforcecli/plugin-info/pull/1246
@W-23661850@